### PR TITLE
fix: IDEV-3077 instant serialisation truncated to millis

### DIFF
--- a/ocpp-1-6-json/src/test/kotlin/com/izivia/ocpp/json16/JsonSerialisationTest.kt
+++ b/ocpp-1-6-json/src/test/kotlin/com/izivia/ocpp/json16/JsonSerialisationTest.kt
@@ -1,0 +1,17 @@
+package com.izivia.ocpp.json16
+
+import com.izivia.ocpp.core16.model.heartbeat.HeartbeatResp
+import kotlinx.datetime.Instant
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class JsonSerialisationTest {
+    val parser = Ocpp16JsonParser()
+
+    @Test
+    fun `should serialize timestamps at millis precision`() {
+        val resp = parser.mapPayloadToString(HeartbeatResp(Instant.parse("2023-10-05T18:04:03.123456Z")))
+        expectThat(resp).isEqualTo("""{"currentTime":"2023-10-05T18:04:03.123Z"}""")
+    }
+}

--- a/utils/src/main/kotlin/com/izivia/ocpp/utils/InstantSerializer.kt
+++ b/utils/src/main/kotlin/com/izivia/ocpp/utils/InstantSerializer.kt
@@ -4,10 +4,26 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import kotlinx.datetime.Instant
+import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toKotlinInstant
+import java.time.temporal.ChronoUnit
+
+private const val NANOS_PER_MILLIS = 1_000_000
 
 class InstantSerializer : StdSerializer<Instant>(Instant::class.java) {
 
     override fun serialize(instant: Instant?, jsonGenerator: JsonGenerator?, serializerProvider: SerializerProvider?) {
-        jsonGenerator?.writeString(instant.toString())
+        jsonGenerator?.writeString(
+            instant.truncateToMillis().toString()
+        )
     }
+
+    private fun Instant?.truncateToMillis() =
+        if (this.nanosOfMillis() != 0) {
+            this?.toJavaInstant()?.truncatedTo(ChronoUnit.MILLIS)?.toKotlinInstant()
+        } else {
+            this
+        }
+
+    private fun Instant?.nanosOfMillis() = (this?.nanosecondsOfSecond ?: 0) % NANOS_PER_MILLIS
 }


### PR DESCRIPTION
as of OCPP specification, the limit of fractional seconds is 3 (=> milliseconds)