### PR TITLE
fix: improve wamp stability

### DIFF
--- a/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/OcppWampClient.kt
+++ b/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/OcppWampClient.kt
@@ -2,6 +2,7 @@ package com.izivia.ocpp.wamp.client
 
 import com.izivia.ocpp.CSOcppId
 import com.izivia.ocpp.OcppVersion
+import com.izivia.ocpp.wamp.client.autoreconnect.AutoReconnectConfig
 import com.izivia.ocpp.wamp.client.autoreconnect.AutoReconnectOcppWampClient
 import com.izivia.ocpp.wamp.client.impl.OkHttpOcppWampClient
 import com.izivia.ocpp.wamp.messages.WampMessage
@@ -32,8 +33,10 @@ interface OcppWampClient {
                 AutoReconnectOcppWampClient(
                     it,
                     it.debugContext,
-                    timeoutInMs.milliseconds,
-                    baseAutoReconnectDelayInMs.milliseconds
+                    AutoReconnectConfig(
+                        timeoutInMs.milliseconds,
+                        baseAutoReconnectDelayInMs.milliseconds
+                    )
                 )
             } else {
                 it

--- a/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/OcppWampClient.kt
+++ b/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/OcppWampClient.kt
@@ -2,17 +2,21 @@ package com.izivia.ocpp.wamp.client
 
 import com.izivia.ocpp.CSOcppId
 import com.izivia.ocpp.OcppVersion
+import com.izivia.ocpp.wamp.client.autoreconnect.AutoReconnectOcppWampClient
 import com.izivia.ocpp.wamp.client.impl.OkHttpOcppWampClient
 import com.izivia.ocpp.wamp.messages.WampMessage
 import com.izivia.ocpp.wamp.messages.WampMessageMeta
 import com.izivia.ocpp.wamp.messages.WampMessageMetaHeaders
 import org.http4k.core.Uri
+import kotlin.time.Duration.Companion.milliseconds
 
 interface OcppWampClient {
-    fun connect()
+    fun connect(listener: ConnectionListener? = null)
     fun close()
     fun sendBlocking(message: WampMessage): WampMessage
     fun onAction(fn: WampOnActionHandler)
+
+    val state: ConnectionState
 
     companion object {
         fun newClient(
@@ -23,16 +27,29 @@ interface OcppWampClient {
             autoReconnect: Boolean = true,
             baseAutoReconnectDelayInMs: Long = 250,
             headers: WampMessageMetaHeaders = emptyList()
-        ) = OkHttpOcppWampClient(
-            target,
-            ocppId,
-            ocppVersion,
-            timeoutInMs,
-            autoReconnect,
-            baseAutoReconnectDelayInMs,
-            headers
-        )
+        ) = OkHttpOcppWampClient(target, ocppId, ocppVersion, timeoutInMs, headers).let {
+            if (autoReconnect) {
+                AutoReconnectOcppWampClient(
+                    it,
+                    it.debugContext,
+                    timeoutInMs.milliseconds,
+                    baseAutoReconnectDelayInMs.milliseconds
+                )
+            } else {
+                it
+            }
+        }
     }
 }
 
 typealias WampOnActionHandler = (WampMessageMeta, WampMessage) -> WampMessage?
+
+enum class ConnectionState {
+    CONNECTING, CONNECTED, DISCONNECTING, DISCONNECTED
+}
+
+interface ConnectionListener {
+    fun onConnected() {}
+    fun onConnectionFailure(t: Throwable) {}
+    fun onConnectionLost(t: Throwable?) {}
+}

--- a/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/AutoReconnectConfig.kt
+++ b/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/AutoReconnectConfig.kt
@@ -1,0 +1,15 @@
+package com.izivia.ocpp.wamp.client.autoreconnect
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+data class AutoReconnectConfig(
+    // the timeout used for calls (sendBlocking), including time to make auto reconnection attempts.
+    val callTimeout: Duration = 30.seconds,
+    // initial delay before trying to reconnect. This delay will be doubled after each attempt, until successful
+    val baseAutoReconnectDelay: Duration = 250.milliseconds,
+    // minimum delay before trying to reconnect. This delay will prevent to make too much reconection attempts
+    // when reconnection attempts are triggered by send calls
+    val minDelayBetweenAttempts: Duration = 100.milliseconds
+)

--- a/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/AutoReconnectHandler.kt
+++ b/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/AutoReconnectHandler.kt
@@ -1,0 +1,206 @@
+package com.izivia.ocpp.wamp.client.autoreconnect
+
+import com.izivia.ocpp.wamp.client.ConnectionListener
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import org.slf4j.LoggerFactory
+import java.util.*
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.math.max
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+internal class AutoReconnectHandler(
+    val debugContext: String,
+    val tryToConnect: () -> Throwable?,
+    val connectionListener: ConnectionListener,
+    // initial delay before trying to reconnect. This delay will be doubled after each attempt, until successful
+    val baseAutoReconnectDelay: Duration = 250.milliseconds,
+    // minimum delay before trying to reconnect. This delay will prevent to make too much reconection attempts
+    // when reconnection attempts are triggered by send calls
+    val minDelayBetweenAttempts: Duration = 100.milliseconds
+) {
+    private val clock = Clock.System
+    private val executor = Executors.newScheduledThreadPool(1)
+    private val lock = ReentrantLock()
+    private val lastConnectionAttempts: MutableList<ConnectionAttempt> = LinkedList()
+    private var nextAttemptDelayInMs: Long = baseAutoReconnectDelay.inWholeMilliseconds
+    private var closed: Boolean = false
+
+    fun checkIsCleanAndReady() {
+        if (!lastConnectionAttempts.isEmpty()) {
+            throw IllegalStateException("[$debugContext] non clean state: $lastConnectionAttempts")
+        }
+        if (closed) {
+            throw IllegalStateException("[$debugContext] auto reconnect handler closed")
+        }
+    }
+
+    fun planConnectionAttemptNow() {
+        planConnectionAttempt(clock.now())
+    }
+
+    fun planConnectionAttempt(scheduleAt: Instant, checkCurrentAttempt: Boolean = true) {
+        withLock {
+            val lastAttemptOrNull = lastConnectionAttempts.lastOrNull()
+            if (checkCurrentAttempt) {
+                lastAttemptOrNull?.also { currentAttempt ->
+                    when (currentAttempt.state) {
+                        is PlannedConnectionAttemptState -> {
+                            if (currentAttempt.scheduledAt > scheduleAt) {
+                                currentAttempt.cancel().also { updateAttempt(it) }
+                            } else {
+                                logger.info(
+                                    "[$debugContext] ignoring call to plan connection attempt," +
+                                        " another one is already planned before: $currentAttempt"
+                                )
+                                return
+                            }
+                        }
+
+                        else -> {
+                            logger.info(
+                                "[$debugContext] there is an ongoing connection attempt," +
+                                    " letting it finish and trigger another one asap if needed: $currentAttempt"
+                            )
+                            // this attempt is ongoing or done and will trigger a next attempt,
+                            // we just need to adjust its delay
+
+                            // 0 delay is immediate, next planning will take care of ensuring a minimum delay
+                            // between attempts if needed
+                            nextAttemptDelayInMs = 0
+                            return
+                        }
+                    }
+                }
+            }
+
+            val attemptCount = (lastAttemptOrNull?.attemptCount ?: 0) + 1
+
+            val now = clock.now()
+            val adjustedScheduledAt =
+                listOfNotNull(
+                    // at least minDelayBetweenAttempts since last completed attempt
+                    lastConnectionAttempts.lastOrNull { it.state.completed }?.scheduledAt
+                        ?.let { it + minDelayBetweenAttempts },
+                    now + 5.milliseconds,
+                    scheduleAt
+                ).maxOrNull()!!
+
+            val attempt = ConnectionAttempt(debugContext, attemptCount, now, adjustedScheduledAt).also {
+                logger.info("[$debugContext] queuing new reconnection attempt $attemptCount")
+                lastConnectionAttempts.add(it)
+                if (lastConnectionAttempts.size > 3) {
+                    lastConnectionAttempts.removeFirst()
+                }
+            }
+
+            executor.schedule(
+                {
+                    try {
+                        attemptToConnectAndPlanNextIfFailed(attempt)
+                    } catch (e: Exception) {
+                        logger.error(
+                            "[$debugContext] attempt ${attempt.attemptCount} unexpected error $e" +
+                                " - planning another one",
+                            e
+                        )
+                        onAttemptFailed(attempt, now, e)
+                    }
+                },
+                (adjustedScheduledAt - now).inWholeMilliseconds,
+                TimeUnit.MILLISECONDS
+            ).let { future ->
+                attempt.plan(future).also { updateAttempt(it) }
+            }
+        }
+    }
+
+    private fun attemptToConnectAndPlanNextIfFailed(attempt: ConnectionAttempt) {
+        withLock {
+            val lastAttemptOrNull = lastConnectionAttempts.lastOrNull()
+            if (closed) {
+                logger.info("[$debugContext] cancelling (closed)")
+                lastAttemptOrNull?.cancel()?.also { updateAttempt(it) }
+                return
+            }
+            if (lastAttemptOrNull?.attemptCount != attempt.attemptCount) {
+                logger.info("[$debugContext] replanning - not current attempt - ${lastAttemptOrNull?.attemptCount}")
+                // current attempt has changed, replan
+                planConnectionAttemptNow()
+                return
+            }
+            lastAttemptOrNull.ongoing(clock.now()).also { updateAttempt(it) }
+        }
+
+        tryToConnect().also { t ->
+            lock.withLock {
+                if (closed) {
+                    lastConnectionAttempts.lastOrNull()?.cancel()?.also { updateAttempt(it) }
+                    return
+                }
+                val now = clock.now()
+                if (t == null) {
+                    currentAttempt(attempt).success(now).also { updateAttempt(it) }
+                    connectionListener.onConnected()
+                } else {
+                    onAttemptFailed(attempt, now, t)
+                }
+            }
+        }
+    }
+
+    private fun onAttemptFailed(attempt: ConnectionAttempt, now: Instant, t: Throwable) {
+        currentAttempt(attempt).failed(now, t).also { updateAttempt(it) }
+
+        planConnectionAttempt(now + nextAttemptDelayInMs.milliseconds, false)
+        nextAttemptDelayInMs =
+            max(baseAutoReconnectDelay.inWholeMilliseconds, nextAttemptDelayInMs) * 2
+        connectionListener.onConnectionFailure(t)
+    }
+
+    private fun currentAttempt(attempt: ConnectionAttempt) =
+        lastConnectionAttempts.firstOrNull { it.attemptCount == attempt.attemptCount }
+            ?: throw IllegalStateException("no current attempt ${attempt.attemptCount}")
+
+    private fun updateAttempt(attempt: ConnectionAttempt) {
+        withLock {
+            // attempt count is unique in the collection for a single instance of AutoReconnectHandler
+            val index = lastConnectionAttempts.indexOfFirst { it.attemptCount == attempt.attemptCount }
+            if (index == -1) {
+                logger.warn(
+                    "[$debugContext] connection attempt [${attempt.attemptCount}] not found" +
+                        " in last connection attempts, aborting update.\n" +
+                        "attempt=$attempt;\nhistory=$lastConnectionAttempts"
+                )
+            } else {
+                if (index != lastConnectionAttempts.size - 1) {
+                    logger.warn(
+                        "[$debugContext] updating non current connection attempt [${attempt.attemptCount}]." +
+                            " Current=${lastConnectionAttempts.lastOrNull()}"
+                    )
+                }
+                lastConnectionAttempts[index] = attempt
+                if (logger.isDebugEnabled) {
+                    logger.debug("[$debugContext] attempt updated => $attempt")
+                }
+            }
+        }
+    }
+
+    fun close() {
+        withLock {
+            closed = true
+            lastConnectionAttempts.lastOrNull()?.cancel()?.also { updateAttempt(it) }
+        }
+    }
+
+    inline fun <T> withLock(action: () -> T) = lock.withLock(action)
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(AutoReconnectHandler::class.java)
+    }
+}

--- a/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/AutoReconnectOcppWampClient.kt
+++ b/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/AutoReconnectOcppWampClient.kt
@@ -6,28 +6,24 @@ import com.izivia.ocpp.wamp.client.OcppWampClient
 import com.izivia.ocpp.wamp.client.WampOnActionHandler
 import com.izivia.ocpp.wamp.messages.WampMessage
 import org.slf4j.LoggerFactory
-import java.io.IOException
-import java.util.concurrent.*
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
+/**
+ * An ocpp wamp client that wraps another client to add auto reconnection feature.
+ *
+ * Once connect is called, this client makes the best efforts to keep the connection to server, until close is called.
+ *
+ * Make sure to call close to stop the auto reconnection process if not needed anymore.
+ */
 class AutoReconnectOcppWampClient(
     val client: OcppWampClient,
     val debugContext: String,
-    // the timeout used for calls (sendBlocking), including time to make auto reconnection attempts.
-    val callTimeout: Duration = 30.seconds,
-    // initial delay before trying to reconnect. This delay will be doubled after each attempt, until successful
-    val baseAutoReconnectDelay: Duration = 250.milliseconds,
-    // minimum delay before trying to reconnect. This delay will prevent to make too much reconection attempts
-    // when reconnection attempts are triggered by send calls
-    val minDelayBetweenAttempts: Duration = 100.milliseconds
+    val config: AutoReconnectConfig
 ) : OcppWampClient {
 
     private val lock = ReentrantLock()
-    private var autoReconnectState: AutoReconnectState = AutoReconnectIdleState()
+    private var autoReconnectState: AutoReconnectState = AutoReconnectIdleState(debugContext)
     private var connectionListener: ConnectionListener? = null
 
     override val state: ConnectionState
@@ -61,6 +57,10 @@ class AutoReconnectOcppWampClient(
             connectionListener = listener
         }
         autoReconnectState.onConnecting()
+        when (autoReconnectState) {
+            is AutoReconnectIdleState -> moveTo(autoReconnectState, connectingState())
+            is AutoReconnectConnectedState, is AutoReconnectConnectingState -> {}
+        }
     }
 
     /**
@@ -69,6 +69,11 @@ class AutoReconnectOcppWampClient(
     override fun close() {
         logger.info("[$debugContext] close (current state=${autoReconnectState::class.simpleName})")
         autoReconnectState.onClose()
+        when (autoReconnectState) {
+            is AutoReconnectIdleState -> {}
+            is AutoReconnectConnectedState, is AutoReconnectConnectingState ->
+                moveTo(autoReconnectState, AutoReconnectIdleState(debugContext))
+        }
         lock.withLock {
             connectionListener = null
         }
@@ -82,6 +87,54 @@ class AutoReconnectOcppWampClient(
     override fun onAction(fn: WampOnActionHandler) {
         client.onAction(fn)
     }
+
+    private fun emitConnected() {
+        autoReconnectState.onConnected()
+        when (autoReconnectState) {
+            is AutoReconnectConnectedState -> {}
+            is AutoReconnectIdleState, is AutoReconnectConnectingState ->
+                moveTo(autoReconnectState, AutoReconnectConnectedState(debugContext))
+        }
+        connectionListener?.onConnected()
+    }
+
+    private fun emitConnectionLost(t: Throwable?) {
+        autoReconnectState.onDisconnected()
+        when (autoReconnectState) {
+            is AutoReconnectIdleState, is AutoReconnectConnectingState -> {}
+            is AutoReconnectConnectedState -> moveTo(autoReconnectState, connectingState())
+        }
+        connectionListener?.onConnectionLost(t)
+    }
+
+    private fun emitConnectionFailure(t: Throwable) {
+        autoReconnectState.onDisconnected()
+        when (autoReconnectState) {
+            is AutoReconnectIdleState, is AutoReconnectConnectingState -> {}
+            is AutoReconnectConnectedState -> moveTo(autoReconnectState, connectingState())
+        }
+        connectionListener?.onConnectionFailure(t)
+    }
+
+    private fun connectingState() =
+        AutoReconnectConnectingState(
+            debugContext,
+            config,
+            { l -> client.connect(l) },
+            object : ConnectionListener {
+                override fun onConnected() {
+                    emitConnected()
+                }
+
+                override fun onConnectionFailure(t: Throwable) {
+                    emitConnectionFailure(t)
+                }
+
+                override fun onConnectionLost(t: Throwable?) {
+                    emitConnectionLost(t)
+                }
+            }
+        )
 
     private fun moveTo(from: AutoReconnectState, to: AutoReconnectState) {
         lock.withLock {
@@ -99,184 +152,6 @@ class AutoReconnectOcppWampClient(
             to.enter()
         }
     }
-
-    private fun emitConnected() {
-        autoReconnectState.onConnected()
-        connectionListener?.onConnected()
-    }
-
-    private fun emitConnectionLost(t: Throwable?) {
-        autoReconnectState.onDisconnected()
-        connectionListener?.onConnectionLost(t)
-    }
-
-    private fun emitConnectionFailure(t: Throwable) {
-        autoReconnectState.onDisconnected()
-        connectionListener?.onConnectionFailure(t)
-    }
-
-    companion object {
-        private val logger = LoggerFactory.getLogger(AutoReconnectOcppWampClient::class.java)
-    }
-
-    private sealed class AutoReconnectState(
-        val debugContext: String,
-        val moveTo: (AutoReconnectState, AutoReconnectState) -> Unit
-    ) {
-
-        fun moveTo(to: AutoReconnectState) {
-            moveTo(this, to)
-        }
-
-        open fun enter() {}
-        open fun exit(to: AutoReconnectState) {}
-
-        open fun onConnecting() {
-            throw unsupported("onConnecting")
-        }
-
-        open fun onConnected() {
-            throw unsupported("onConnected")
-        }
-
-        open fun onBeforeCall() {
-            throw unsupported("onBeforeCall")
-        }
-
-        open fun onDisconnected() {
-            throw unsupported("onDisconnected")
-        }
-
-        open fun onClose() {
-            throw unsupported("onClose")
-        }
-
-        private fun unsupported(op: String) = IllegalStateException(
-            "[$debugContext] $op not supported when state is ${this::class.simpleName}"
-        )
-    }
-
-    private inner class AutoReconnectIdleState : AutoReconnectState(debugContext, { f, t -> moveTo(f, t) }) {
-        override fun onConnecting() {
-            moveTo(AutoReconnectConnectingState())
-        }
-
-        override fun onClose() {
-            // nothing to do, already idle
-        }
-
-        override fun onDisconnected() {
-            // nothing to do, if because of concurrency we receive a disconnection event while closed, that's ok
-        }
-
-        override fun onBeforeCall() {
-            throw IllegalStateException("[$debugContext] not connected")
-        }
-    }
-
-    private inner class AutoReconnectConnectingState() : AutoReconnectState(debugContext, { f, t -> moveTo(f, t) }) {
-        private val handler = AutoReconnectHandler(
-            debugContext,
-            {
-                try {
-                    client.connect(object : ConnectionListener {
-                        // we handle only connection lost, connection failure will throw an exception
-                        // and onConnected is handled by the AutoReconnectHandler
-
-                        override fun onConnectionLost(t: Throwable?) {
-                            emitConnectionLost(t)
-                        }
-                    })
-                    null
-                } catch (t: Throwable) {
-                    t
-                }
-            },
-            object : ConnectionListener {
-                override fun onConnected() {
-                    emitConnected()
-                }
-
-                override fun onConnectionFailure(t: Throwable) {
-                    emitConnectionFailure(t)
-                }
-            },
-            baseAutoReconnectDelay,
-            minDelayBetweenAttempts
-        )
-        private val connectionLatch = CountDownLatch(1)
-
-        override fun enter() {
-            handler.checkIsCleanAndReady()
-            if (connectionLatch.count != 1L) {
-                throw IllegalStateException(
-                    "$debugContext - invalid state, connection count down latch is not 1: ${connectionLatch.count}"
-                )
-            }
-
-            logger.info("[$debugContext] connecting [auto-reconnect ON]")
-            handler.planConnectionAttemptNow()
-        }
-
-        override fun onConnected() {
-            connectionLatch.countDown()
-            moveTo(AutoReconnectConnectedState())
-        }
-
-        override fun onBeforeCall() {
-            handler.planConnectionAttemptNow()
-            logger.debug("[$debugContext] waiting for reconnection for at most $callTimeout")
-            if (!connectionLatch.await(callTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)) {
-                throw IOException("[$debugContext] currently not connected - retry later")
-            }
-        }
-
-        override fun onConnecting() {
-            // nothing to do, already in connecting state
-        }
-
-        override fun onDisconnected() {
-            // nothing to do, we are here to make retries
-        }
-
-        override fun onClose() {
-            handler.close()
-            moveTo(AutoReconnectIdleState())
-        }
-    }
-
-    private inner class AutoReconnectConnectedState : AutoReconnectState(debugContext, { f, t -> moveTo(f, t) }) {
-        override fun enter() {
-            logger.info("[$debugContext] connected [auto-reconnect ON]")
-        }
-
-        override fun exit(to: AutoReconnectState) {
-            when (to) {
-                is AutoReconnectConnectingState ->
-                    logger.info("[$debugContext] disconnected [auto-reconnect ON]")
-
-                is AutoReconnectIdleState ->
-                    logger.info("[$debugContext] disconnected [close]")
-
-                is AutoReconnectConnectedState ->
-                    logger.info("[$debugContext] disconnected [new connection]")
-            }
-        }
-
-        override fun onDisconnected() {
-            moveTo(AutoReconnectConnectingState())
-        }
-
-        override fun onClose() {
-            moveTo(AutoReconnectIdleState())
-        }
-
-        override fun onBeforeCall() {
-            // nothing to do, already connected
-        }
-
-        override fun onConnecting() {
-            // nothing to do, already connected
-        }
-    }
 }
+
+private val logger = LoggerFactory.getLogger(AutoReconnectOcppWampClient::class.java)

--- a/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/AutoReconnectOcppWampClient.kt
+++ b/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/AutoReconnectOcppWampClient.kt
@@ -1,0 +1,282 @@
+package com.izivia.ocpp.wamp.client.autoreconnect
+
+import com.izivia.ocpp.wamp.client.ConnectionListener
+import com.izivia.ocpp.wamp.client.ConnectionState
+import com.izivia.ocpp.wamp.client.OcppWampClient
+import com.izivia.ocpp.wamp.client.WampOnActionHandler
+import com.izivia.ocpp.wamp.messages.WampMessage
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.util.concurrent.*
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class AutoReconnectOcppWampClient(
+    val client: OcppWampClient,
+    val debugContext: String,
+    // the timeout used for calls (sendBlocking), including time to make auto reconnection attempts.
+    val callTimeout: Duration = 30.seconds,
+    // initial delay before trying to reconnect. This delay will be doubled after each attempt, until successful
+    val baseAutoReconnectDelay: Duration = 250.milliseconds,
+    // minimum delay before trying to reconnect. This delay will prevent to make too much reconection attempts
+    // when reconnection attempts are triggered by send calls
+    val minDelayBetweenAttempts: Duration = 100.milliseconds
+) : OcppWampClient {
+
+    private val lock = ReentrantLock()
+    private var autoReconnectState: AutoReconnectState = AutoReconnectIdleState()
+    private var connectionListener: ConnectionListener? = null
+
+    override val state: ConnectionState
+        get() = when (autoReconnectState) {
+            is AutoReconnectIdleState -> ConnectionState.DISCONNECTED
+            is AutoReconnectConnectingState -> ConnectionState.CONNECTING
+            is AutoReconnectConnectedState -> ConnectionState.CONNECTED
+        }
+
+    /**
+     * Asynchronously attempt to connect to the remote wamp server.
+     *
+     * Once called, this client is in auto reconnect mode, and will always do its best to keep the connection
+     * to the wamp server.
+     *
+     * You can be notified of connections and deconnection by providing a ConnectionListener as parameter.
+     *
+     * Note that this method does not throw an exception if connection fails, since the connection may later be
+     * available. So you need to listen to events, or use a client without auto reconnect if you are not sure
+     * of the wamp server url or port and rather want to test a connection.
+     */
+    override fun connect(listener: ConnectionListener?) {
+        logger.info("[$debugContext] connect (current state=${autoReconnectState::class.simpleName})")
+        lock.withLock {
+            if (connectionListener != null) {
+                throw IllegalStateException(
+                    "[$debugContext] can't connect with connection listener" +
+                        " while already connected with another listener"
+                )
+            }
+            connectionListener = listener
+        }
+        autoReconnectState.onConnecting()
+    }
+
+    /**
+     * Closes the current connection to server (if connected) and stops any further auto reconnection attempt
+     */
+    override fun close() {
+        logger.info("[$debugContext] close (current state=${autoReconnectState::class.simpleName})")
+        autoReconnectState.onClose()
+        lock.withLock {
+            connectionListener = null
+        }
+    }
+
+    override fun sendBlocking(message: WampMessage): WampMessage {
+        autoReconnectState.onBeforeCall()
+        return client.sendBlocking(message)
+    }
+
+    override fun onAction(fn: WampOnActionHandler) {
+        client.onAction(fn)
+    }
+
+    private fun moveTo(from: AutoReconnectState, to: AutoReconnectState) {
+        lock.withLock {
+            if (autoReconnectState != from) {
+                logger.error(
+                    "[$debugContext] auto reconnect state change not accepted:" +
+                        " expected from=$from; " +
+                        "current=$autoReconnectState; " +
+                        "requested to move to: $to"
+                )
+                return
+            }
+            autoReconnectState.exit(to)
+            autoReconnectState = to
+            to.enter()
+        }
+    }
+
+    private fun emitConnected() {
+        autoReconnectState.onConnected()
+        connectionListener?.onConnected()
+    }
+
+    private fun emitConnectionLost(t: Throwable?) {
+        autoReconnectState.onDisconnected()
+        connectionListener?.onConnectionLost(t)
+    }
+
+    private fun emitConnectionFailure(t: Throwable) {
+        autoReconnectState.onDisconnected()
+        connectionListener?.onConnectionFailure(t)
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(AutoReconnectOcppWampClient::class.java)
+    }
+
+    private sealed class AutoReconnectState(
+        val debugContext: String,
+        val moveTo: (AutoReconnectState, AutoReconnectState) -> Unit
+    ) {
+
+        fun moveTo(to: AutoReconnectState) {
+            moveTo(this, to)
+        }
+
+        open fun enter() {}
+        open fun exit(to: AutoReconnectState) {}
+
+        open fun onConnecting() {
+            throw unsupported("onConnecting")
+        }
+
+        open fun onConnected() {
+            throw unsupported("onConnected")
+        }
+
+        open fun onBeforeCall() {
+            throw unsupported("onBeforeCall")
+        }
+
+        open fun onDisconnected() {
+            throw unsupported("onDisconnected")
+        }
+
+        open fun onClose() {
+            throw unsupported("onClose")
+        }
+
+        private fun unsupported(op: String) = IllegalStateException(
+            "[$debugContext] $op not supported when state is ${this::class.simpleName}"
+        )
+    }
+
+    private inner class AutoReconnectIdleState : AutoReconnectState(debugContext, { f, t -> moveTo(f, t) }) {
+        override fun onConnecting() {
+            moveTo(AutoReconnectConnectingState())
+        }
+
+        override fun onClose() {
+            // nothing to do, already idle
+        }
+
+        override fun onDisconnected() {
+            // nothing to do, if because of concurrency we receive a disconnection event while closed, that's ok
+        }
+
+        override fun onBeforeCall() {
+            throw IllegalStateException("[$debugContext] not connected")
+        }
+    }
+
+    private inner class AutoReconnectConnectingState() : AutoReconnectState(debugContext, { f, t -> moveTo(f, t) }) {
+        private val handler = AutoReconnectHandler(
+            debugContext,
+            {
+                try {
+                    client.connect(object : ConnectionListener {
+                        // we handle only connection lost, connection failure will throw an exception
+                        // and onConnected is handled by the AutoReconnectHandler
+
+                        override fun onConnectionLost(t: Throwable?) {
+                            emitConnectionLost(t)
+                        }
+                    })
+                    null
+                } catch (t: Throwable) {
+                    t
+                }
+            },
+            object : ConnectionListener {
+                override fun onConnected() {
+                    emitConnected()
+                }
+
+                override fun onConnectionFailure(t: Throwable) {
+                    emitConnectionFailure(t)
+                }
+            },
+            baseAutoReconnectDelay,
+            minDelayBetweenAttempts
+        )
+        private val connectionLatch = CountDownLatch(1)
+
+        override fun enter() {
+            handler.checkIsCleanAndReady()
+            if (connectionLatch.count != 1L) {
+                throw IllegalStateException(
+                    "$debugContext - invalid state, connection count down latch is not 1: ${connectionLatch.count}"
+                )
+            }
+
+            logger.info("[$debugContext] connecting [auto-reconnect ON]")
+            handler.planConnectionAttemptNow()
+        }
+
+        override fun onConnected() {
+            connectionLatch.countDown()
+            moveTo(AutoReconnectConnectedState())
+        }
+
+        override fun onBeforeCall() {
+            handler.planConnectionAttemptNow()
+            logger.debug("[$debugContext] waiting for reconnection for at most $callTimeout")
+            if (!connectionLatch.await(callTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)) {
+                throw IOException("[$debugContext] currently not connected - retry later")
+            }
+        }
+
+        override fun onConnecting() {
+            // nothing to do, already in connecting state
+        }
+
+        override fun onDisconnected() {
+            // nothing to do, we are here to make retries
+        }
+
+        override fun onClose() {
+            handler.close()
+            moveTo(AutoReconnectIdleState())
+        }
+    }
+
+    private inner class AutoReconnectConnectedState : AutoReconnectState(debugContext, { f, t -> moveTo(f, t) }) {
+        override fun enter() {
+            logger.info("[$debugContext] connected [auto-reconnect ON]")
+        }
+
+        override fun exit(to: AutoReconnectState) {
+            when (to) {
+                is AutoReconnectConnectingState ->
+                    logger.info("[$debugContext] disconnected [auto-reconnect ON]")
+
+                is AutoReconnectIdleState ->
+                    logger.info("[$debugContext] disconnected [close]")
+
+                is AutoReconnectConnectedState ->
+                    logger.info("[$debugContext] disconnected [new connection]")
+            }
+        }
+
+        override fun onDisconnected() {
+            moveTo(AutoReconnectConnectingState())
+        }
+
+        override fun onClose() {
+            moveTo(AutoReconnectIdleState())
+        }
+
+        override fun onBeforeCall() {
+            // nothing to do, already connected
+        }
+
+        override fun onConnecting() {
+            // nothing to do, already connected
+        }
+    }
+}

--- a/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/AutoReconnectState.kt
+++ b/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/AutoReconnectState.kt
@@ -1,0 +1,112 @@
+package com.izivia.ocpp.wamp.client.autoreconnect
+
+import com.izivia.ocpp.wamp.client.ConnectionListener
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Represents the state of an AutoReconnect client.
+ *
+ * It can be either:
+ * - Idle, when the client is not supposed to be connected, either because connect has not been called
+ *         or after a call to close
+ * - Connecting, when the client is not connected, while it should be.
+ *         In this mode, the client frequently attempts to reconnect
+ * - Connected, when the client is properly connected to the server.
+ */
+internal sealed interface AutoReconnectState {
+    fun enter() {}
+    fun exit(to: AutoReconnectState) {}
+    fun onConnecting() {}
+    fun onConnected() {}
+    fun onBeforeCall() {}
+    fun onDisconnected() {}
+    fun onClose() {}
+}
+
+internal class AutoReconnectConnectedState(val debugContext: String) : AutoReconnectState {
+    override fun enter() {
+        logger.info("[$debugContext] connected [auto-reconnect ON]")
+    }
+
+    override fun exit(to: AutoReconnectState) {
+        when (to) {
+            is AutoReconnectConnectingState ->
+                logger.info("[$debugContext] disconnected [auto-reconnect ON]")
+
+            is AutoReconnectIdleState ->
+                logger.info("[$debugContext] disconnected [close]")
+
+            is AutoReconnectConnectedState ->
+                logger.info("[$debugContext] disconnected [new connection]")
+        }
+    }
+}
+
+internal class AutoReconnectConnectingState(
+    private val debugContext: String,
+    private val config: AutoReconnectConfig,
+    doConnect: (l: ConnectionListener) -> Unit,
+    connectionListener: ConnectionListener
+) : AutoReconnectState {
+    private val handler = AutoReconnectHandler(
+        debugContext,
+        {
+            try {
+                doConnect(object : ConnectionListener {
+                    // we handle only connection lost, connection failure will throw an exception
+                    // and onConnected is handled by the AutoReconnectHandler
+
+                    override fun onConnectionLost(t: Throwable?) {
+                        connectionListener.onConnectionLost(t)
+                    }
+                })
+                null
+            } catch (t: Throwable) {
+                t
+            }
+        },
+        connectionListener,
+        config.baseAutoReconnectDelay,
+        config.minDelayBetweenAttempts
+    )
+    private val connectionLatch = CountDownLatch(1)
+
+    override fun enter() {
+        handler.checkIsCleanAndReady()
+        if (connectionLatch.count != 1L) {
+            throw IllegalStateException(
+                "$debugContext - invalid state, connection count down latch is not 1: ${connectionLatch.count}"
+            )
+        }
+
+        logger.info("[$debugContext] connecting [auto-reconnect ON]")
+        handler.planConnectionAttemptNow()
+    }
+
+    override fun onConnected() {
+        connectionLatch.countDown()
+    }
+
+    override fun onBeforeCall() {
+        handler.planConnectionAttemptNow()
+        logger.debug("[$debugContext] waiting for reconnection for at most $config.callTimeout")
+        if (!connectionLatch.await(config.callTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)) {
+            throw IOException("[$debugContext] currently not connected - retry later")
+        }
+    }
+
+    override fun onClose() {
+        handler.close()
+    }
+}
+
+internal class AutoReconnectIdleState(val debugContext: String) : AutoReconnectState {
+    override fun onBeforeCall() {
+        throw IllegalStateException("[$debugContext] not connected")
+    }
+}
+
+private val logger = LoggerFactory.getLogger(AutoReconnectState::class.java)

--- a/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/ConnectionAttempt.kt
+++ b/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/wamp/client/autoreconnect/ConnectionAttempt.kt
@@ -1,0 +1,147 @@
+package com.izivia.ocpp.wamp.client.autoreconnect
+
+import kotlinx.datetime.Instant
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ScheduledFuture
+import kotlin.time.Duration
+
+/**
+ * Represents an attempt to connect to a Wamp server
+ * The attempt follows a state lifecycle:
+ * - Queued - when the attempt is initialled created
+ * - Planned - when the attempt is planned to be performed at a schedule instant
+ * - Ongoing - when the attempt is being performed
+ * - Successful - when the attempt has resulted to a a successful connection
+ * - Failed - when the attempt has failed, and another attempt is needed
+ * - Cancelled - when the attempt has been cancelled, usually in favor of another attempt
+ *           (or because the client is closed)
+ */
+internal class ConnectionAttempt private constructor(
+    val debugContext: String,
+    val attemptCount: Int,
+    val plannedAt: Instant, // at what time was this time planned, ie when it was created
+    val scheduledAt: Instant, // at what time this attempt is scheduled to be performed
+    val state: ConnectionAttemptState,
+    val stateHistory: List<ConnectionAttemptState>
+) {
+
+    private constructor(
+        debugContext: String,
+        attemptCount: Int,
+        plannedAt: Instant,
+        scheduledAt: Instant,
+        state: ConnectionAttemptState
+    ) :
+        this(debugContext, attemptCount, plannedAt, scheduledAt, state, listOf(state))
+
+    constructor(
+        debugContext: String,
+        attemptCount: Int,
+        plannedAt: Instant, // at what time was this time planned, ie when it was created
+        scheduledAt: Instant
+    ) :
+        this(debugContext, attemptCount, plannedAt, scheduledAt, QueuedConnectionAttemptState())
+
+    fun cancel(): ConnectionAttempt {
+        if (state is PlannedConnectionAttemptState) {
+            state.future.cancel(false)
+        }
+        return moveTo(CancelledConnectionAttemptState())
+    }
+
+    fun moveTo(state: ConnectionAttemptState) =
+        ConnectionAttempt(debugContext, attemptCount, plannedAt, scheduledAt, state, stateHistory + state)
+            .also { logger.info("[$debugContext] connection attempt $attemptCount => ${state::class.simpleName}") }
+
+    fun plan(future: ScheduledFuture<*>) =
+        checkStateToMove<QueuedConnectionAttemptState>("plan")
+            .let { moveTo(PlannedConnectionAttemptState(future)) }
+
+    fun ongoing(startedAt: Instant) =
+        checkStateToMove<PlannedConnectionAttemptState>("ongoing")
+            .let { moveTo(OngoingConnectionAttemptState(startedAt)) }
+
+    fun success(successAt: Instant) =
+        checkStateToMove<OngoingConnectionAttemptState>("success")
+            .let { moveTo(SuccessfulConnectionAttemptState(successAt, successAt - it.startedAt)) }
+
+    fun failed(failedAt: Instant, t: Throwable) =
+        checkStateToMove<OngoingConnectionAttemptState>("failed")
+            .let {
+                moveTo(
+                    FailedConnectionAttemptState(
+                        failedAt,
+                        failedAt - it.startedAt,
+                        t::class.simpleName + ": " + (t.message ?: ""),
+                        t
+                    )
+                )
+            }
+
+    inline fun <reified S> checkStateToMove(target: String): S = if (state is S) {
+        state
+    } else {
+        throw IllegalStateException(
+            "can't move to $target state from ${this.state::class.simpleName} - attempt=$this"
+        )
+    }
+
+    override fun toString(): String {
+        return "[$debugContext] ConnectionAttempt(" +
+            "attemptCount=$attemptCount, " +
+            "plannedAt=$plannedAt, " +
+            "scheduledAt=$scheduledAt, " +
+            "state=$state, " +
+            "stateHistory=$stateHistory)"
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(AutoReconnectHandler::class.java)
+    }
+}
+
+internal sealed class ConnectionAttemptState {
+    abstract val completed: Boolean // true if the attempt has been completed, successfully or not
+}
+
+internal class QueuedConnectionAttemptState : ConnectionAttemptState() {
+    override val completed: Boolean
+        get() = false
+}
+
+internal data class PlannedConnectionAttemptState(
+    val future: ScheduledFuture<*> // the future used to track this attempt
+) : ConnectionAttemptState() {
+    override val completed: Boolean
+        get() = false
+}
+
+internal class CancelledConnectionAttemptState : ConnectionAttemptState() {
+    override val completed: Boolean
+        get() = false
+}
+
+internal data class OngoingConnectionAttemptState(
+    val startedAt: Instant
+) : ConnectionAttemptState() {
+    override val completed: Boolean
+        get() = false
+}
+
+internal data class SuccessfulConnectionAttemptState(
+    val connectedAt: Instant,
+    val duration: Duration
+) : ConnectionAttemptState() {
+    override val completed: Boolean
+        get() = true
+}
+
+internal data class FailedConnectionAttemptState(
+    val failedAt: Instant,
+    val duration: Duration,
+    val errorMessage: String,
+    val error: Throwable?
+) : ConnectionAttemptState() {
+    override val completed: Boolean
+        get() = true
+}

--- a/ocpp-wamp/src/test/kotlin/com/izivia/ocpp/wamp/WampIntegrationTest.kt
+++ b/ocpp-wamp/src/test/kotlin/com/izivia/ocpp/wamp/WampIntegrationTest.kt
@@ -214,7 +214,12 @@ class WampIntegrationTest {
         server.start()
 
         try {
-            val client = OcppWampClient.newClient(Uri.of("ws://localhost:$port/ws"), "TEST1", OCPP_1_6)
+            val client = OcppWampClient.newClient(
+                Uri.of("ws://localhost:$port/ws"),
+                "TEST1",
+                OCPP_1_6,
+                autoReconnect = false
+            )
             client.onAction { meta: WampMessageMeta, msg: WampMessage ->
                 when (msg.action?.lowercase()) {
                     "remotebeat" ->
@@ -333,7 +338,13 @@ class WampIntegrationTest {
 
     @Test
     fun `should cleanly fail on connection when no server`() {
-        val client = OcppWampClient.newClient(Uri.of("ws://localhost:$port/ws"), "TEST1", OCPP_1_6, timeoutInMs = 500)
+        val client = OcppWampClient.newClient(
+            Uri.of("ws://localhost:$port/ws"),
+            "TEST1",
+            OCPP_1_6,
+            timeoutInMs = 500,
+            autoReconnect = false
+        )
         expectCatching { client.connect() }.isFailure()
         expectCatching { client.sendBlocking(WampMessage.Call("1", "Heartbeat", "{}")) }.isFailure()
 
@@ -418,7 +429,8 @@ class WampIntegrationTest {
             Uri.of("ws://localhost:$port/ws"),
             "TEST1",
             OCPP_1_6,
-            timeoutInMs = 50
+            timeoutInMs = 50,
+            autoReconnect = false
         )
         val time = measureTimeMillis {
             expectCatching { client.connect() }.isFailure()


### PR DESCRIPTION
This includes changes to both wamp server (minor changes) and wamp client (major changes) to improve stability.

The auto reconnect feature of the client has been fully rewritten to make it easier to reason around state and race conditions. The aim is to make it more stable, and solve the issues we had with flaky WampIntegrationTest.

On my machine, I've run WampIntegrationTest a bunch of time and while before it was failing from time to time, it is now passing all the time.

The build on github action will say if it's more stable there too.