### PR TITLE
feat: add transactionId mapping for setChargingProfileReq in Ocpp16CS…

### DIFF
--- a/ocpp-1-6-api-adapter/src/main/kotlin/com/izivia/ocpp/adapter16/Ocpp16CSApiAdapter.kt
+++ b/ocpp-1-6-api-adapter/src/main/kotlin/com/izivia/ocpp/adapter16/Ocpp16CSApiAdapter.kt
@@ -263,7 +263,13 @@ class Ocpp16CSApiAdapter(
         req: SetChargingProfileReq
     ): OperationExecution<SetChargingProfileReq, SetChargingProfileResp> {
         val mapper: SetChargingProfileMapper = Mappers.getMapper(SetChargingProfileMapper::class.java)
-        val response = csApi.setChargingProfile(meta, mapper.coreToGenReq(req))
+        val transactionId = req.csChargingProfiles.transactionId
+            ?.let { transactionIds.getLocalIdByTransactionId(it) }
+            ?.localId
+        val response = csApi.setChargingProfile(
+            meta,
+            mapper.coreToGenReq(req)
+                .let { it.copy(chargingProfile = it.chargingProfile.copy(transactionId = transactionId)) })
         return OperationExecution(
             ExecutionMetadata(meta, RequestStatus.SUCCESS),
             req,

--- a/ocpp-1-6-api-adapter/src/test/kotlin/com/izivia/ocpp/adapter16/test/CSApiAdapterTest.kt
+++ b/ocpp-1-6-api-adapter/src/test/kotlin/com/izivia/ocpp/adapter16/test/CSApiAdapterTest.kt
@@ -1,0 +1,91 @@
+package com.izivia.ocpp.adapter16.test
+
+import com.izivia.ocpp.adapter16.Ocpp16CSApiAdapter
+import com.izivia.ocpp.adapter16.Ocpp16TransactionIds
+import com.izivia.ocpp.adapter16.impl.RealTransactionRepository
+import com.izivia.ocpp.api.CSApi
+import com.izivia.ocpp.api.model.common.enumeration.ChargingProfilePurposeEnumType
+import com.izivia.ocpp.api.model.setchargingprofile.SetChargingProfileResp
+import com.izivia.ocpp.api.model.setchargingprofile.enumeration.ChargingProfileStatusEnumType
+import com.izivia.ocpp.core16.model.common.ChargingProfile
+import com.izivia.ocpp.core16.model.common.ChargingSchedule
+import com.izivia.ocpp.core16.model.common.enumeration.ChargingProfilePurposeType
+import com.izivia.ocpp.core16.model.common.enumeration.ChargingRateUnitType
+import com.izivia.ocpp.core16.model.remotestart.ChargingSchedulePeriod
+import com.izivia.ocpp.core16.model.remotestart.enumeration.ChargingProfileKindType
+import com.izivia.ocpp.core16.model.setchargingprofile.SetChargingProfileReq
+import com.izivia.ocpp.core16.model.setchargingprofile.enumeration.ChargingProfileStatus
+import com.izivia.ocpp.operation.information.ExecutionMetadata
+import com.izivia.ocpp.operation.information.OperationExecution
+import com.izivia.ocpp.operation.information.RequestMetadata
+import com.izivia.ocpp.operation.information.RequestStatus
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class CSApiAdapterTest {
+    private lateinit var csApi: CSApi
+
+    @BeforeEach
+    fun init() {
+        csApi = mockk()
+    }
+
+    @AfterEach
+    fun destroy() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `setChargingProfile request`() {
+        val transactionIds = RealTransactionRepository()
+        transactionIds.saveTransactionIds(Ocpp16TransactionIds(localId = "4", csmsId = 2))
+        val requestMetadata = RequestMetadata("")
+
+        every { csApi.setChargingProfile(any(), any()) } answers {
+            val req = secondArg<com.izivia.ocpp.api.model.setchargingprofile.SetChargingProfileReq>()
+            OperationExecution(
+                executionMeta = ExecutionMetadata(reqMeta = requestMetadata, status = RequestStatus.SUCCESS),
+                request = req,
+                response = SetChargingProfileResp(
+                    status = when {
+                        req.chargingProfile.chargingProfilePurpose == ChargingProfilePurposeEnumType.ChargingStationMaxProfile
+                                && req.chargingProfile.transactionId == null -> ChargingProfileStatusEnumType.Accepted
+
+                        req.chargingProfile.chargingProfilePurpose == ChargingProfilePurposeEnumType.TxProfile
+                                && req.chargingProfile.transactionId == "4" -> ChargingProfileStatusEnumType.Accepted
+
+                        else -> ChargingProfileStatusEnumType.Rejected
+                    }
+                )
+            )
+        }
+
+        val operations = Ocpp16CSApiAdapter(csApi, transactionIds)
+        val request = SetChargingProfileReq(
+            connectorId = 1,
+            csChargingProfiles = ChargingProfile(
+                chargingProfileId = 1,
+                stackLevel = 2,
+                chargingProfilePurpose = ChargingProfilePurposeType.TxProfile,
+                chargingProfileKind = ChargingProfileKindType.Relative,
+                chargingSchedule = ChargingSchedule(
+                    ChargingRateUnitType.A,
+                    listOf(ChargingSchedulePeriod(1, 1))
+                ),
+                transactionId = 2
+            )
+        )
+        val response = operations.setChargingProfile(requestMetadata, request)
+
+        expectThat(response) {
+            get { this.request }.isEqualTo(request)
+            get { this.response.status }.isEqualTo(ChargingProfileStatus.Accepted)
+        }
+    }
+}

--- a/ocpp-1-6-api-adapter/src/test/kotlin/com/izivia/ocpp/adapter16/test/MapperTest.kt
+++ b/ocpp-1-6-api-adapter/src/test/kotlin/com/izivia/ocpp/adapter16/test/MapperTest.kt
@@ -513,11 +513,10 @@ class MapperTest {
                     stackLevel = 2,
                     chargingProfilePurpose = ChargingProfilePurposeType.ChargePointMaxProfile,
                     chargingProfileKind = ChargingProfileKindType.Absolute,
-                    chargingSchedule = ChargingSchedule(ChargingRateUnitType.A, listOf(ChargingSchedulePeriod(1, 1))),
-                    transactionId = 1
+                    chargingSchedule = ChargingSchedule(ChargingRateUnitType.A, listOf(ChargingSchedulePeriod(1, 1)))
                 )
             )
-        ).let { it.copy(chargingProfile = it.chargingProfile.copy(transactionId = "4")) }
+        )
         expectThat(req)
             .and { get { evseId }.isEqualTo(1) }
             .and { get { chargingProfile.id }.isEqualTo(1) }
@@ -539,7 +538,6 @@ class MapperTest {
                     )
                 )
             }
-            .and { get { chargingProfile.transactionId }.isEqualTo("4") }
     }
 
     @Test

--- a/ocpp-1-6-api-adapter/src/test/kotlin/com/izivia/ocpp/adapter16/test/MapperTest.kt
+++ b/ocpp-1-6-api-adapter/src/test/kotlin/com/izivia/ocpp/adapter16/test/MapperTest.kt
@@ -513,10 +513,11 @@ class MapperTest {
                     stackLevel = 2,
                     chargingProfilePurpose = ChargingProfilePurposeType.ChargePointMaxProfile,
                     chargingProfileKind = ChargingProfileKindType.Absolute,
-                    chargingSchedule = ChargingSchedule(ChargingRateUnitType.A, listOf(ChargingSchedulePeriod(1, 1)))
+                    chargingSchedule = ChargingSchedule(ChargingRateUnitType.A, listOf(ChargingSchedulePeriod(1, 1))),
+                    transactionId = 1
                 )
             )
-        )
+        ).let { it.copy(chargingProfile = it.chargingProfile.copy(transactionId = "4")) }
         expectThat(req)
             .and { get { evseId }.isEqualTo(1) }
             .and { get { chargingProfile.id }.isEqualTo(1) }
@@ -538,6 +539,7 @@ class MapperTest {
                     )
                 )
             }
+            .and { get { chargingProfile.transactionId }.isEqualTo("4") }
     }
 
     @Test

--- a/ocpp-2-0-api-adapter/src/test/kotlin/com/izivia/ocpp/adapter20/test/CSApiAdapterTest.kt
+++ b/ocpp-2-0-api-adapter/src/test/kotlin/com/izivia/ocpp/adapter20/test/CSApiAdapterTest.kt
@@ -1,0 +1,87 @@
+package com.izivia.ocpp.adapter20.test
+
+import com.izivia.ocpp.adapter20.Ocpp20CSApiAdapter
+import com.izivia.ocpp.api.CSApi
+import com.izivia.ocpp.api.model.common.enumeration.ChargingProfilePurposeEnumType as ChargingProfilePurposeEnumTypeGen
+import com.izivia.ocpp.api.model.setchargingprofile.SetChargingProfileResp
+import com.izivia.ocpp.api.model.setchargingprofile.enumeration.ChargingProfileStatusEnumType as ChargingProfileStatusEnumTypeGen
+import com.izivia.ocpp.core20.model.common.ChargingProfileType
+import com.izivia.ocpp.core20.model.common.ChargingSchedulePeriodType
+import com.izivia.ocpp.core20.model.common.ChargingScheduleType
+import com.izivia.ocpp.core20.model.common.enumeration.ChargingProfilePurposeEnumType
+import com.izivia.ocpp.core20.model.common.enumeration.ChargingRateUnitEnumType
+import com.izivia.ocpp.core20.model.remotestart.enumeration.ChargingProfileKindEnumType
+import com.izivia.ocpp.core20.model.setchargingprofile.SetChargingProfileReq
+import com.izivia.ocpp.core20.model.setchargingprofile.enumeration.ChargingProfileStatusEnumType
+import com.izivia.ocpp.operation.information.ExecutionMetadata
+import com.izivia.ocpp.operation.information.OperationExecution
+import com.izivia.ocpp.operation.information.RequestMetadata
+import com.izivia.ocpp.operation.information.RequestStatus
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class CSApiAdapterTest {
+    private lateinit var csApi: CSApi
+
+    @BeforeEach
+    fun init() {
+        csApi = mockk()
+    }
+
+    @AfterEach
+    fun destroy() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `setChargingProfile request`() {
+        val requestMetadata = RequestMetadata("")
+
+        every { csApi.setChargingProfile(any(), any()) } answers {
+            val req = secondArg<com.izivia.ocpp.api.model.setchargingprofile.SetChargingProfileReq>()
+            OperationExecution(
+                executionMeta = ExecutionMetadata(requestMetadata, RequestStatus.SUCCESS),
+                req,
+                SetChargingProfileResp(
+                    status = when {
+                        req.chargingProfile.chargingProfilePurpose == ChargingProfilePurposeEnumTypeGen.ChargingStationMaxProfile
+                                && req.chargingProfile.transactionId == null -> ChargingProfileStatusEnumTypeGen.Accepted
+
+                        req.chargingProfile.chargingProfilePurpose == ChargingProfilePurposeEnumTypeGen.TxProfile
+                                && req.chargingProfile.transactionId == "1" -> ChargingProfileStatusEnumTypeGen.Accepted
+
+                        else -> ChargingProfileStatusEnumTypeGen.Rejected
+                    }
+                )
+            )
+        }
+
+        val operations = Ocpp20CSApiAdapter(csApi)
+        val request = SetChargingProfileReq(
+            evseId = 1,
+            chargingProfile = ChargingProfileType(
+                id = 1,
+                stackLevel = 2,
+                chargingProfilePurpose = ChargingProfilePurposeEnumType.ChargingStationMaxProfile,
+                chargingProfileKind = ChargingProfileKindEnumType.Relative,
+                chargingSchedule = listOf(
+                    ChargingScheduleType(
+                        1, ChargingRateUnitEnumType.A, listOf(ChargingSchedulePeriodType(1, 1.0))
+                    )
+                )
+            )
+        )
+        val response = operations.setChargingProfile(requestMetadata, request)
+
+        expectThat(response) {
+            get { this.request }.isEqualTo(request)
+            get { this.response.status }.isEqualTo(ChargingProfileStatusEnumType.Accepted)
+        }
+    }
+}


### PR DESCRIPTION
Ajout de la correspondance transactionId du CSMS vers la borne pour une requête setChargingProfile

⚠️ Je n'ai pas pu testé en local car les transactionId ne sont pas gérés avec SteVe