### PR TITLE
Fixed EVSEType in OCPP 1.6 version

### DIFF
--- a/ocpp-1-6-api-adapter/src/main/kotlin/com/izivia/ocpp/adapter16/mapper/CommonMapper.kt
+++ b/ocpp-1-6-api-adapter/src/main/kotlin/com/izivia/ocpp/adapter16/mapper/CommonMapper.kt
@@ -128,11 +128,7 @@ abstract class CommonMapper {
     @Named("convertEVSEType")
     fun convertEVSEType(evse: EVSEType?): Int =
         if (evse != null) {
-            if (evse.connectorId != null && evse.connectorId != evse.id) {
-                throw IllegalArgumentException("Argument evse can't have different id and connectorId : ${evse.id} != ${evse.connectorId}")
-            } else {
-                evse.id
-            }
+            evse.connectorId!!
         } else {
             throw IllegalArgumentException("Argument evse is required in OCPP 1.6 to start a transaction")
         }


### PR DESCRIPTION
Use connector ID instead of evse in 1.6 + Do not throw exception if evseId != connectorId