### PR TITLE
feat: EVSIM-437 add message id in request metadata

### DIFF
--- a/ocpp-transport-soap/src/main/kotlin/com/izivia/ocpp/http/OcppSoapServerTransport.kt
+++ b/ocpp-transport-soap/src/main/kotlin/com/izivia/ocpp/http/OcppSoapServerTransport.kt
@@ -105,7 +105,7 @@ class OcppSoapServerTransport private constructor(
                         msg.action?.lowercase() == action.lowercase()
                     ) {
                         val message = ocppSoapParser.parseRequestFromSoap(msg.payload, clazz)
-                        val response = onAction(RequestMetadata(message.messageId), message.payload)
+                        val response = onAction(RequestMetadata(message.messageId, message.messageId), message.payload)
                         val payload = ocppSoapParser.mapResponseToSoap(
                             ResponseSoapMessage(
                                 messageId = "urn:uuid:${newMessageId()}",

--- a/ocpp-transport-soap/src/main/kotlin/com/izivia/ocpp/http/OcppSoapServerTransport.kt
+++ b/ocpp-transport-soap/src/main/kotlin/com/izivia/ocpp/http/OcppSoapServerTransport.kt
@@ -105,7 +105,7 @@ class OcppSoapServerTransport private constructor(
                         msg.action?.lowercase() == action.lowercase()
                     ) {
                         val message = ocppSoapParser.parseRequestFromSoap(msg.payload, clazz)
-                        val response = onAction(RequestMetadata(message.messageId, message.messageId), message.payload)
+                        val response = onAction(RequestMetadata(message.chargingStationId, message.messageId), message.payload)
                         val payload = ocppSoapParser.mapResponseToSoap(
                             ResponseSoapMessage(
                                 messageId = "urn:uuid:${newMessageId()}",

--- a/ocpp-transport-websocket/src/main/kotlin/com/izivia/ocpp/websocket/WebsocketServer.kt
+++ b/ocpp-transport-websocket/src/main/kotlin/com/izivia/ocpp/websocket/WebsocketServer.kt
@@ -71,7 +71,10 @@ class WebsocketServer(
                     val parser = getJsonMapper(OcppVersionWamp.valueOf(ocppVersion.name))
                     try {
                         val response =
-                            onAction(RequestMetadata(meta.ocppId), parser.parsePayloadFromJson(msg.payload, clazz))
+                            onAction(
+                                RequestMetadata(meta.ocppId, msg.msgId),
+                                parser.parsePayloadFromJson(msg.payload, clazz)
+                            )
                         val payload = parser.mapPayloadToString(response)
                         WampMessage.CallResult(msg.msgId, payload)
                     } catch (e: Exception) { // TODO Better mapping of exceptions https://izivia.atlassian.net/browse/IDEV-497

--- a/operation-information/src/main/kotlin/com/izivia/ocpp/operation/information/RequestMetadata.kt
+++ b/operation-information/src/main/kotlin/com/izivia/ocpp/operation/information/RequestMetadata.kt
@@ -1,5 +1,6 @@
 package com.izivia.ocpp.operation.information
 
 data class RequestMetadata(
-    val chargingStationId: String
+    val chargingStationId: String,
+    val messageId: String? = null
 )


### PR DESCRIPTION
https://4sh-toolkit.atlassian.net/browse/EVSIM-437

Ajout du message id dans les request metadata afin qu'il soit directement accessible lors de l'implémentation des callbacks, qui ont la signature suivante par exemple : 
```
fun authorize(meta: RequestMetadata, request: AuthorizeReq): OperationExecution<AuthorizeReq, AuthorizeResp>
```
