### PR TITLE
Fix PeriodicClockAligned typo in MonitorEnumType

### DIFF
--- a/generic-api/src/main/kotlin/com/izivia/ocpp/api/model/common/enumeration/MonitorEnumType.kt
+++ b/generic-api/src/main/kotlin/com/izivia/ocpp/api/model/common/enumeration/MonitorEnumType.kt
@@ -9,5 +9,5 @@ enum class MonitorEnumType(val value: String) {
 
     Periodic("Periodic"),
 
-    PeriodicClockAligne("PeriodicClockAligne")
+    PeriodicClockAligned("PeriodicClockAligned")
 }

--- a/ocpp-2-0-core/src/main/kotlin/com/izivia/ocpp/core20/model/common/enumeration/MonitorEnumType.kt
+++ b/ocpp-2-0-core/src/main/kotlin/com/izivia/ocpp/core20/model/common/enumeration/MonitorEnumType.kt
@@ -9,5 +9,5 @@ enum class MonitorEnumType(val value: String) {
 
     Periodic("Periodic"),
 
-    PeriodicClockAligne("PeriodicClockAligne")
+    PeriodicClockAligned("PeriodicClockAligned")
 }


### PR DESCRIPTION
Hi!
There is a typo in the MonitorEnumType which caused some deserialization errors for me.