### PR TITLE
fix: fix incorrect usage of clientSettings.path as route

### DIFF
--- a/ocpp-transport-soap/src/main/kotlin/com/izivia/ocpp/http/OcppSoapClientTransport.kt
+++ b/ocpp-transport-soap/src/main/kotlin/com/izivia/ocpp/http/OcppSoapClientTransport.kt
@@ -12,7 +12,6 @@ import org.http4k.server.Http4kServer
 import org.http4k.server.Undertow
 import org.http4k.server.asServer
 import org.slf4j.LoggerFactory
-import java.lang.IllegalStateException
 import java.util.*
 import kotlin.reflect.KClass
 
@@ -37,8 +36,7 @@ class OcppSoapClientTransport(
     private val handlers = mutableListOf<(HttpMessage) -> HttpMessage?>()
 
     init {
-        val route =
-            clientSettings.path bindContract Method.POST to ::routeHandler
+        val route = "/" bindContract Method.POST to ::routeHandler
         val app = contract {
             routes += route
         }


### PR DESCRIPTION
clientSettings.path is the client host that is used in the `from` header of sent OCPP message

If we use `clientSettings.path` as route, the client will have to send his message to `clientSettings.path:clientSettings.port/clientSettings.path`. Example: if `clientSettings.path = http://localhost` and `clientSettings.port = 8080` , the client will have to send his messages to `http://localhost:8080/http://localhost`