### PR TITLE
chore(gradle) update sonatype urls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("jvm") apply true
     id("com.google.protobuf") version "0.8.18" apply false
     id("maven-publish")
-    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
 val versionNumber = System.getenv("VERSION")?.substringAfter("R-") ?: "dev"
@@ -94,8 +94,8 @@ subprojects {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set(System.getenv("SONATYPE_USERNAME"))
             password.set(System.getenv("SONATYPE_PASSWORD"))
         }


### PR DESCRIPTION
OSSRH reached its end-of-life on June 30, 2025. The migration is straightforward, the URLs need to be changed. Also updated to the latest version, 2.0.0