### PR TITLE
feat: allow supplying OcppWampServerSettings to the websocket server

### DIFF
--- a/ocpp-transport-websocket/src/main/kotlin/com/izivia/ocpp/websocket/WebsocketServer.kt
+++ b/ocpp-transport-websocket/src/main/kotlin/com/izivia/ocpp/websocket/WebsocketServer.kt
@@ -13,8 +13,11 @@ import com.izivia.ocpp.wamp.messages.WampMessageMeta
 import com.izivia.ocpp.wamp.messages.WampMessageType
 import com.izivia.ocpp.wamp.server.OcppWampServer
 import com.izivia.ocpp.wamp.server.OcppWampServerHandler
+import com.izivia.ocpp.wamp.server.asServer
 import com.izivia.ocpp.wamp.server.impl.EventsListeners
+import com.izivia.ocpp.wamp.server.impl.OcppWampServerSettings
 import mu.KotlinLogging
+import org.http4k.server.Http4kServer
 import java.util.*
 import kotlin.reflect.KClass
 import com.izivia.ocpp.OcppVersion as OcppVersionWamp
@@ -25,11 +28,17 @@ class WebsocketServer(
     ocppVersions: Set<OcppVersion>,
     path: String,
     val newMessageId: () -> String = { UUID.randomUUID().toString() },
+    settings: OcppWampServerSettings = OcppWampServerSettings(),
     listeners: EventsListeners = EventsListeners(),
 ) : ServerTransport {
 
-    private val server: OcppWampServer =
-        OcppWampServer.newServer(ocppVersions = ocppVersions.map { OcppVersionWamp.valueOf(it.name) }.toSet(), path = path, listeners = listeners)
+    internal val server: OcppWampServer =
+        OcppWampServer.newServer(
+            ocppVersions = ocppVersions.map { OcppVersionWamp.valueOf(it.name) }.toSet(),
+            path = path,
+            settings = settings,
+            listeners = listeners
+        )
     val serverConfig = server.config()
 
     override fun <T, P : Any> sendMessageClass(clazz: KClass<P>, csOcppId: String, action: String, message: T): P =
@@ -94,3 +103,4 @@ class WebsocketServer(
         chargingStationConfig.acceptConnection
 }
 
+fun WebsocketServer.asServer(port: Int = 8000): Http4kServer = server.asServer(port)

--- a/ocpp-transport-websocket/src/test/kotlin/com/izivia/ocpp/websocket/test/WebsocketServerSettingsTest.kt
+++ b/ocpp-transport-websocket/src/test/kotlin/com/izivia/ocpp/websocket/test/WebsocketServerSettingsTest.kt
@@ -1,0 +1,74 @@
+package com.izivia.ocpp.websocket.test
+
+import com.izivia.ocpp.core16.model.authorize.AuthorizeReq
+import com.izivia.ocpp.core16.model.authorize.AuthorizeResp
+import com.izivia.ocpp.core16.model.common.IdTagInfo
+import com.izivia.ocpp.core16.model.common.enumeration.AuthorizationStatus
+import com.izivia.ocpp.operation.information.ChargingStationConfig
+import com.izivia.ocpp.transport.OcppVersion
+import com.izivia.ocpp.wamp.server.impl.OcppWampServerSettings
+import com.izivia.ocpp.websocket.WebsocketClient
+import com.izivia.ocpp.websocket.WebsocketServer
+import com.izivia.ocpp.websocket.asServer
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isGreaterThanOrEqualTo
+import java.net.ServerSocket
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import com.izivia.ocpp.OcppVersion as OcppVersionWamp
+
+class WebsocketServerSettingsTest {
+
+    /** Settings whose calls executor records how many calls it was asked to run. */
+    private class RecordingSettings : OcppWampServerSettings() {
+        val executedCalls = AtomicInteger()
+        private val delegate = Executors.newSingleThreadExecutor()
+
+        override fun buildCallsExecutor(): Executor = Executor { command ->
+            executedCalls.incrementAndGet()
+            delegate.execute(command)
+        }
+
+        fun shutdown() {
+            delegate.shutdownNow()
+        }
+    }
+
+    private fun getFreePort(): Int =
+        ServerSocket(0).use { it.localPort }
+
+    @Test
+    fun `settings given to WebsocketServer are used to handle inbound calls`() {
+        val port = getFreePort()
+        val settings = RecordingSettings()
+
+        val transport = WebsocketServer(setOf(OcppVersion.OCPP_1_6), "ws", settings = settings)
+        transport.receiveMessageClass(
+            clazz = AuthorizeReq::class,
+            action = "authorize",
+            ocppVersion = OcppVersion.OCPP_1_6,
+            onAction = { _, _: AuthorizeReq -> AuthorizeResp(IdTagInfo(AuthorizationStatus.Accepted)) },
+            accept = { ChargingStationConfig(acceptConnection = true, soapUrl = null) }
+        )
+
+        val server = transport.asServer(port)
+        server.start()
+
+        try {
+            val client = WebsocketClient("TEST1", OcppVersionWamp.OCPP_1_6, "ws://localhost:$port/ws")
+            client.connect()
+            try {
+                client.sendMessageClass(AuthorizeResp::class, "authorize", AuthorizeReq("Tag1"))
+            } finally {
+                client.close()
+            }
+
+            expectThat(settings.executedCalls.get()).isGreaterThanOrEqualTo(1)
+        } finally {
+            server.stop()
+            settings.shutdown()
+        }
+    }
+}

--- a/toolkit/src/main/kotlin/com/izivia/ocpp/integration/ApiFactory.kt
+++ b/toolkit/src/main/kotlin/com/izivia/ocpp/integration/ApiFactory.kt
@@ -22,6 +22,7 @@ import com.izivia.ocpp.transport.ClientTransport
 import com.izivia.ocpp.transport.RequestHeaders
 import com.izivia.ocpp.transport.ServerTransport
 import com.izivia.ocpp.wamp.server.impl.EventsListeners
+import com.izivia.ocpp.wamp.server.impl.OcppWampServerSettings
 import com.izivia.ocpp.websocket.WebsocketClient
 import com.izivia.ocpp.websocket.WebsocketServer
 import java.util.*
@@ -101,9 +102,10 @@ class ApiFactory {
             path: String,
             ocppVersion: Set<OcppVersionTransport>,
             newMessageId: () -> String,
+            settings: OcppWampServerSettings,
             listeners: EventsListeners = EventsListeners()
         ): ServerTransport =
-            WebsocketServer(ocppVersion, path, newMessageId, listeners)
+            WebsocketServer(ocppVersion, path, newMessageId, settings, listeners)
 
         private fun createServerTransportSoap(
             path: String,
@@ -216,6 +218,7 @@ class ApiFactory {
                                 s.path,
                                 s.ocppVersion,
                                 s.newMessageId,
+                                s.wampSettings,
                                 s.listeners
                             ) to (s.port to s.ocppVersion)
                         )

--- a/toolkit/src/main/kotlin/com/izivia/ocpp/integration/model/Settings.kt
+++ b/toolkit/src/main/kotlin/com/izivia/ocpp/integration/model/Settings.kt
@@ -2,6 +2,7 @@ package com.izivia.ocpp.integration.model
 
 import com.izivia.ocpp.transport.OcppVersion
 import com.izivia.ocpp.wamp.server.impl.EventsListeners
+import com.izivia.ocpp.wamp.server.impl.OcppWampServerSettings
 import java.util.*
 
 data class Settings(
@@ -28,5 +29,6 @@ data class ServerSetting(
     val ocppVersion: Set<OcppVersion>,
     val transportType: TransportEnum,
     val newMessageId: () -> String = { UUID.randomUUID().toString() },
+    val wampSettings: OcppWampServerSettings = OcppWampServerSettings(),
     var listeners: EventsListeners = EventsListeners()
 )

--- a/toolkit/src/test/kotlin/com/izivia/ocpp/integration/test/ServerSettingSettingsTest.kt
+++ b/toolkit/src/test/kotlin/com/izivia/ocpp/integration/test/ServerSettingSettingsTest.kt
@@ -1,0 +1,53 @@
+package com.izivia.ocpp.integration.test
+
+import com.izivia.ocpp.integration.ApiFactory.Companion.csmsOcppServer
+import com.izivia.ocpp.integration.model.CSMSSettings
+import com.izivia.ocpp.integration.model.ServerSetting
+import com.izivia.ocpp.integration.model.TransportEnum
+import com.izivia.ocpp.operation.information.ChargingStationConfig
+import com.izivia.ocpp.transport.OcppVersion
+import com.izivia.ocpp.wamp.server.impl.OcppWampServerSettings
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import strikt.api.expectThat
+import strikt.assertions.isTrue
+import java.util.concurrent.Executor
+import com.izivia.ocpp.core16.ChargePointOperations as ChargePointOperations16
+
+class ServerSettingSettingsTest {
+
+    /** Settings that record whether the wamp server ever asked them for a calls executor. */
+    private class RecordingSettings : OcppWampServerSettings() {
+        var callsExecutorBuilt = false
+            private set
+
+        override fun buildCallsExecutor(): Executor {
+            callsExecutorBuilt = true
+            return Executor { it.run() }
+        }
+    }
+
+    @Test
+    fun `settings given to ServerSetting reach the websocket server`() {
+        val settings = RecordingSettings()
+
+        // The server is only built here, never started, so the port is never bound.
+        csmsOcppServer(
+            csmsSettings = CSMSSettings(
+                listOf(
+                    ServerSetting(
+                        port = 8080,
+                        ocppVersion = setOf(OcppVersion.OCPP_1_6),
+                        transportType = TransportEnum.WEBSOCKET,
+                        wampSettings = settings
+                    )
+                )
+            ),
+            csmsApiCallbacks = listOf(mock<ChargePointOperations16>()),
+            fn = { ChargingStationConfig(acceptConnection = true, soapUrl = null) }
+        )
+
+        // The wamp server builds the calls executor eagerly, when the transport is created.
+        expectThat(settings.callsExecutorBuilt).isTrue()
+    }
+}


### PR DESCRIPTION
`OcppWampServer.newServer(...)` already accepts an `OcppWampServerSettings`, and both the class and
its `buildCallsExecutor()` method are `open` — overriding them is clearly an intended extension
point. `WebsocketServer` never passes one, so anyone using the WebSocket transport is locked to the
defaults with no override path.

## What is unreachable today

**The calls executor.** `OcppWampServerApp` builds it once from `settings.buildCallsExecutor()` and
then calls `callsExecutor.execute { ... }` **per inbound CALL message** — the `execute` sits inside
the `ws.onMessage` lambda, not per connection. The default is `Executors.newCachedThreadPool()`:
`corePoolSize = 0`, `maximumPoolSize = Integer.MAX_VALUE`, `SynchronousQueue`. Live threads
therefore track the number of messages concurrently in flight, with no ceiling and no back-pressure.
When message handling slows down — a slow database, a lock, a GC pause — arriving messages each
spawn a new thread, and at roughly 0.5–1 MB of stack per thread that ends in
`OutOfMemoryError: unable to create native thread` or a container OOM kill. Overriding
`buildCallsExecutor()` is exactly the intended remedy; it is just not reachable from this transport.

**`timeoutInMs`** (default 30 s), the OCPP call timeout forwarded to every `WampCallManager`, for the
same reason.

## The change

`WebsocketServer` gains `settings: OcppWampServerSettings = OcppWampServerSettings()` and forwards
it to `newServer(...)`. The parameter sits between `newMessageId` and `listeners` so the ordering
mirrors `newServer(ocppVersions, path, settings, listeners)`.

The same value is threaded through `ServerSetting.wampSettings` → `ApiFactory.csmsOcppServer` →
`createServerTransportWebsocket`, following the path `EventsListeners` already takes. Without that,
the gap would simply move up one level: users of the high-level `CSMS` API could still not configure
anything.

One small addition came out of writing the test: `fun WebsocketServer.asServer(port)`, mirroring the
existing `OcppWampServer.asServer(port)` and `OcppSoapServerTransport.asServer(port)`. Starting a
`WebsocketServer` previously meant reassembling the Undertow config from `serverConfig` by hand, so
the WebSocket transport was the only one of the three without that affordance. Happy to drop it if
you would rather keep the PR to the settings parameter alone.

## Compatibility

Source compatibility is preserved for named-argument and default-argument call sites. Positional
four-argument calls such as the previous `WebsocketServer(ocppVersion, path, newMessageId, listeners)`
now get a clear type-mismatch compile error; inserting the new argument (or naming them) fixes it, as
done here in `ApiFactory`.

`ServerSetting` is the quieter case: it is a public `data class`, so inserting the property before
`listeners` shifts `component6()`/`component7()` and positional `copy(...)`. Unlike the constructor
change above, a destructuring such as `val (a, b, c, d, e, f) = serverSetting` keeps compiling and
silently binds a different value. That is accepted here to keep the ordering aligned with
`newServer(...)`, but it is the one place in this PR where the break is not loud.

Binary compatibility is deliberately **not** preserved, and I would suggest releasing this in the
next minor. Adding a constructor parameter changes the primary constructor's JVM signature, so
pre-compiled callers linking against `(Set, String, Function0, EventsListeners)` will get a
`NoSuchMethodError`. I considered keeping a secondary constructor with the old arity delegating to
the new one, and decided against it: most Kotlin callers omit at least one argument and therefore
link against the synthetic default-argument constructor
`(Set, String, Function0, EventsListeners, int, DefaultConstructorMarker)`, which a secondary
constructor does not restore. It would advertise a compatibility it cannot deliver. Happy to add one
anyway if you would rather cover the exact-arity and Java call sites.

## Verification

`./gradlew build` passes locally on JDK 21, same as CI.

Two tests were added, and both were checked to fail before the production change:

- `WebsocketServerSettingsTest` (ocpp-transport-websocket) starts a real server built from a
  `WebsocketServer` with an `OcppWampServerSettings` subclass whose `buildCallsExecutor()` returns an
  instrumented `Executor`, connects a real `WebsocketClient`, sends an `Authorize` call, and asserts
  the inbound CALL was dispatched on that executor. It deliberately uses `Authorize` rather than
  `Heartbeat` so that no time type appears in the test, which keeps it independent of the
  `kotlinx.datetime` → `kotlin.time` migration.
- `ServerSettingSettingsTest` (toolkit) covers the `ServerSetting` → `ApiFactory` plumbing.

## Related gaps, not addressed here

Each now has a follow-up issue: #102, #103, #104, #105.

- `WebsocketClient` has the symmetric gap: `timeoutInMs`, `autoReconnect` and
  `baseAutoReconnectDelayInMs` from `OcppWampClient.newClient` are not exposed either.
- `ocpp-transport-soap` has no server-side settings type at all, so there is no equivalent knob.
- `ocpp-transport-websocket` declares `implementation(project(":ocpp-wamp"))` while exposing wamp
  types (`EventsListeners`, `WsServerConfig`, and now `OcppWampServerSettings`) in its public API, so
  consumers have to add `com.izivia:ocpp-wamp` themselves to name the new parameter. Pre-existing —
  `listeners` already has it — and `api(...)` would be the fix, but it felt out of scope here.
- `WebsocketServer` does not expose `OcppWampServer.shutdown()` either, so graceful shutdown is
  unreachable from this transport for exactly the same reason the settings were.

Each felt like a separate change; happy to pick any of them up once this lands.
