### PR TITLE
feat: add OCPP 1.2 support over JSON/WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For more information about OCPP (Open Charge Point Protocol), see https://www.op
 The aim is to support:
 - both the CSMS and the Charging Station sides
 - versions 1.2, 1.5, 1.6 and 2.0.1 of OCPP
-- WS/JSON (OCPP-J ; 1.5 and later) and SOAP (OCPP-S ; 1.x versions only) flavor for the transport
+- WS/JSON (OCPP-J ; all versions) and SOAP (OCPP-S ; 1.x versions only) flavor for the transport
 
 It can be used:
 - to simulate a charging station, eg to test a CSMS
@@ -38,7 +38,7 @@ Inbound timestamp parsing is intentionally more tolerant for OCPP interoperabili
 
 Currently the ChargingStation side of versions 1.6 and 2.0.1 are fully supported in OCPP-J flavor - except the security requirements besides support for http basic auth. This includes all the data structures described by the specification, with json serialisation verified against the json schemas provided in the specification.
 
-The CSMS side is available through the `CSMS` entry point, and the SOAP (OCPP-S) flavor is implemented for the 1.x versions. OCPP 1.2 and 1.5 are supported over SOAP, 1.5 also over OCPP-J; OCPP 1.2 has no WebSocket binding, so it is SOAP only. All four versions are reachable through the generic API.
+The CSMS side is available through the `CSMS` entry point, and the SOAP (OCPP-S) flavor is implemented for the 1.x versions. OCPP 1.2 and 1.5 are supported over SOAP, and both also over OCPP-J: the JSON/WebSocket transport is defined independently of message content, and `ocpp1.2` is a registered subprotocol. All four versions are reachable through the generic API.
 
 Support for security requirements like SSL and mutual certificates is under discussion, as it can be achieved using a proxy like Envoy.
 

--- a/ocpp-1-2-json/build.gradle.kts
+++ b/ocpp-1-2-json/build.gradle.kts
@@ -1,0 +1,41 @@
+plugins {
+    kotlin("jvm")
+    `maven-publish`
+}
+
+coreProject()
+
+dependencies {
+    api(project(":ocpp-1-2-core"))
+    api(project(":ocpp-json"))
+
+    implementation("com.fasterxml.jackson.core:jackson-databind:_")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:_")
+    implementation("com.networknt:json-schema-validator:_")
+    implementation(project(mapOf("path" to ":utils")))
+
+    testImplementation(kotlin("test-junit"))
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+publishing {
+    publications {
+        named<MavenPublication>("maven") {
+            groupId = project.group.toString()
+            artifactId = "ocpp-1-2-json"
+            version = project.version.toString()
+
+            from(components["java"])
+
+            pom {
+                name.set("OCPP 1.2 JSON")
+                artifactId = "ocpp-1-2-json"
+                description.set("This module provides a JSON parser for OCPP 1.2")
+            }
+        }
+    }
+}

--- a/ocpp-1-2-json/src/main/kotlin/com/izivia/ocpp/json12/Ocpp12JsonObjectMapper.kt
+++ b/ocpp-1-2-json/src/main/kotlin/com/izivia/ocpp/json12/Ocpp12JsonObjectMapper.kt
@@ -1,0 +1,16 @@
+package com.izivia.ocpp.json12
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.izivia.ocpp.core12.model.changeconfiguration.ChangeConfigurationReq
+import com.izivia.ocpp.json.OcppJsonMapper
+
+internal object Ocpp12JsonObjectMapper : ObjectMapper(
+    OcppJsonMapper()
+        .addMixIn(ChangeConfigurationReq::class.java, ChangeConfigurationReqMixin::class.java)
+)
+
+private abstract class ChangeConfigurationReqMixin {
+    @get:JsonInclude(JsonInclude.Include.ALWAYS)
+    abstract val value: String
+}

--- a/ocpp-1-2-json/src/main/kotlin/com/izivia/ocpp/json12/Ocpp12JsonParser.kt
+++ b/ocpp-1-2-json/src/main/kotlin/com/izivia/ocpp/json12/Ocpp12JsonParser.kt
@@ -1,0 +1,75 @@
+package com.izivia.ocpp.json12
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.izivia.ocpp.core12.Ocpp12ForcedFieldType
+import com.izivia.ocpp.core12.Ocpp12IgnoredNullRestriction
+import com.izivia.ocpp.core12.model.common.enumeration.Actions
+import com.izivia.ocpp.json.JsonMessage
+import com.izivia.ocpp.json.JsonMessageType
+import com.izivia.ocpp.json.OcppJsonParser
+import com.izivia.ocpp.json.OcppJsonValidator
+import com.izivia.ocpp.utils.MessageTypeException
+import com.networknt.schema.SpecVersion
+import com.networknt.schema.ValidationMessage
+import com.networknt.schema.ValidatorTypeCode
+
+class Ocpp12JsonParser(
+    override val ignoredNullRestrictions: List<Ocpp12IgnoredNullRestriction>? = null,
+    override val ignoredValidationCodes: List<ValidatorTypeCode>? = null,
+    override val forcedFieldTypes: List<Ocpp12ForcedFieldType>? = null,
+    enableValidation: Boolean = true
+) :
+    OcppJsonParser(
+        mapper = Ocpp12JsonObjectMapper,
+        forcedFieldTypes = forcedFieldTypes,
+        ignoredValidationCodes = ignoredValidationCodes,
+        ignoredNullRestrictions = ignoredNullRestrictions,
+        // OcppJsonValidator resolves schemas by name off the classpath, where 1.5, 1.6 and 2.0
+        // already ship colliding names, so the 1.2 schemas sit in their own resource folder.
+        ocppJsonValidator = OcppJsonValidator(SpecVersion.VersionFlag.V4, SCHEMA_FOLDER)
+            .takeIf { enableValidation }
+    ) {
+
+    override fun getRequestPayloadClass(action: String, errorHandler: (e: Exception) -> Throwable): Class<out Any> =
+        try {
+            Actions.valueOf(action.uppercase()).classRequest
+        } catch (e: Exception) {
+            throw errorHandler(e)
+        }
+
+    override fun getResponsePayloadClass(action: String, errorHandler: (e: Exception) -> Throwable): Class<out Any> =
+        try {
+            Actions.valueOf(action.uppercase()).classResponse
+        } catch (e: Exception) {
+            throw errorHandler(e)
+        }
+
+    override fun getActionFromClass(className: String): String =
+        Actions.valueOf(getActionFromClassName(className)).value
+
+    override fun validateJson(
+        jsonMessage: JsonMessage<JsonNode>,
+        errorsHandler: (errors: List<ValidationMessage>) -> Unit
+    ) {
+        val action = Actions.valueOf(jsonMessage.action!!.uppercase()).camelCase()
+        ocppJsonValidator?.isValidObject(
+            action = when (jsonMessage.msgType) {
+                JsonMessageType.CALL -> action
+                JsonMessageType.CALL_RESULT -> "${action}Response"
+                JsonMessageType.CALL_ERROR -> return
+                else -> throw MessageTypeException(
+                    message = "MessageType not supported ${jsonMessage.msgType}",
+                    messageId = jsonMessage.msgId
+                )
+            },
+            payload = jsonMessage.payload
+        )
+            ?.let {
+                errorsHandler(it)
+            }
+    }
+
+    private companion object {
+        const val SCHEMA_FOLDER = "ocpp12"
+    }
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/Authorize.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/Authorize.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "AuthorizeRequest",
+    "type": "object",
+    "properties": {
+        "idTag": {
+            "type": "string",
+            "maxLength": 15
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "idTag"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/AuthorizeResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/AuthorizeResponse.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "AuthorizeResponse",
+    "type": "object",
+    "properties": {
+        "idTagInfo": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "additionalProperties": false,
+                    "enum": [
+                        "Accepted",
+                        "Blocked",
+                        "Expired",
+                        "Invalid",
+                        "ConcurrentTx"
+                    ]
+                },
+                "expiryDate": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "parentIdTag": {
+                    "type": "string",
+                    "maxLength": 15
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "status"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "idTagInfo"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/BootNotification.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/BootNotification.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "BootNotificationRequest",
+    "type": "object",
+    "properties": {
+        "chargePointVendor": {
+            "type": "string",
+            "maxLength": 20
+        },
+        "chargePointModel": {
+            "type": "string",
+            "maxLength": 20
+        },
+        "chargePointSerialNumber": {
+            "type": "string",
+            "maxLength": 25
+        },
+        "chargeBoxSerialNumber": {
+            "type": "string",
+            "maxLength": 25
+        },
+        "firmwareVersion": {
+            "type": "string",
+            "maxLength": 20
+        },
+        "iccid": {
+            "type": "string",
+            "maxLength": 20
+        },
+        "imsi": {
+            "type": "string",
+            "maxLength": 20
+        },
+        "meterType": {
+            "type": "string",
+            "maxLength": 25
+        },
+        "meterSerialNumber": {
+            "type": "string",
+            "maxLength": 25
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "chargePointVendor",
+        "chargePointModel"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/BootNotificationResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/BootNotificationResponse.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "BootNotificationResponse",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Accepted",
+                "Rejected"
+            ]
+        },
+        "currentTime": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "heartbeatInterval": {
+            "type": "integer"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "status"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/ChangeAvailability.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/ChangeAvailability.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ChangeAvailabilityRequest",
+    "type": "object",
+    "properties": {
+        "connectorId": {
+            "type": "integer"
+        },
+        "type": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Inoperative",
+                "Operative"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "connectorId",
+        "type"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/ChangeAvailabilityResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/ChangeAvailabilityResponse.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ChangeAvailabilityResponse",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Accepted",
+                "Rejected",
+                "Scheduled"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "status"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/ChangeConfiguration.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/ChangeConfiguration.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ChangeConfigurationRequest",
+    "type": "object",
+    "properties": {
+        "key": {
+            "type": "string",
+            "maxLength": 50
+        },
+        "value": {
+            "type": "string",
+            "maxLength": 500
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "key",
+        "value"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/ChangeConfigurationResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/ChangeConfigurationResponse.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ChangeConfigurationResponse",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Accepted",
+                "Rejected",
+                "NotSupported"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "status"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/ClearCache.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/ClearCache.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ClearCacheRequest",
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/ClearCacheResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/ClearCacheResponse.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ClearCacheResponse",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Accepted",
+                "Rejected"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "status"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/DiagnosticsStatusNotification.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/DiagnosticsStatusNotification.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "DiagnosticsStatusNotificationRequest",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Uploaded",
+                "UploadFailed"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "status"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/DiagnosticsStatusNotificationResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/DiagnosticsStatusNotificationResponse.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "DiagnosticsStatusNotificationResponse",
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/FirmwareStatusNotification.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/FirmwareStatusNotification.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "FirmwareStatusNotificationRequest",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Downloaded",
+                "DownloadFailed",
+                "InstallationFailed",
+                "Installed"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "status"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/FirmwareStatusNotificationResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/FirmwareStatusNotificationResponse.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "FirmwareStatusNotificationResponse",
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/GetDiagnostics.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/GetDiagnostics.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "GetDiagnosticsRequest",
+    "type": "object",
+    "properties": {
+        "location": {
+            "type": "string"
+        },
+        "startTime": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "stopTime": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "retries": {
+            "type": "integer"
+        },
+        "retryInterval": {
+            "type": "integer"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "location"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/GetDiagnosticsResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/GetDiagnosticsResponse.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "GetDiagnosticsResponse",
+    "type": "object",
+    "properties": {
+        "fileName": {
+            "type": "string",
+            "maxLength": 255
+        }
+    },
+    "additionalProperties": false
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/Heartbeat.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/Heartbeat.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "HeartbeatRequest",
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/HeartbeatResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/HeartbeatResponse.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "HeartbeatResponse",
+    "type": "object",
+    "properties": {
+        "currentTime": {
+            "type": "string",
+            "format": "date-time"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "currentTime"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/MeterValues.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/MeterValues.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "MeterValuesRequest",
+    "type": "object",
+    "properties": {
+        "connectorId": {
+            "type": "integer"
+        },
+        "values": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "value": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "timestamp",
+                    "value"
+                ]
+            }
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "connectorId"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/MeterValuesResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/MeterValuesResponse.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "MeterValuesResponse",
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/RemoteStartTransaction.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/RemoteStartTransaction.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "RemoteStartTransactionRequest",
+    "type": "object",
+    "properties": {
+        "idTag": {
+            "type": "string",
+            "maxLength": 15
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "idTag"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/RemoteStartTransactionResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/RemoteStartTransactionResponse.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "RemoteStartTransactionResponse",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Accepted",
+                "Rejected"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "status"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/RemoteStopTransaction.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/RemoteStopTransaction.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "RemoteStopTransactionRequest",
+    "type": "object",
+    "properties": {
+        "transactionId": {
+            "type": "integer"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "transactionId"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/RemoteStopTransactionResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/RemoteStopTransactionResponse.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "RemoteStopTransactionResponse",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Accepted",
+                "Rejected"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "status"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/Reset.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/Reset.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ResetRequest",
+    "type": "object",
+    "properties": {
+        "type": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Hard",
+                "Soft"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "type"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/ResetResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/ResetResponse.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ResetResponse",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Accepted",
+                "Rejected"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "status"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/StartTransaction.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/StartTransaction.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "StartTransactionRequest",
+    "type": "object",
+    "properties": {
+        "connectorId": {
+            "type": "integer"
+        },
+        "idTag": {
+            "type": "string",
+            "maxLength": 15
+        },
+        "timestamp": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "meterStart": {
+            "type": "integer"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "connectorId",
+        "idTag",
+        "timestamp",
+        "meterStart"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/StartTransactionResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/StartTransactionResponse.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "StartTransactionResponse",
+    "type": "object",
+    "properties": {
+        "transactionId": {
+            "type": "integer"
+        },
+        "idTagInfo": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "additionalProperties": false,
+                    "enum": [
+                        "Accepted",
+                        "Blocked",
+                        "Expired",
+                        "Invalid",
+                        "ConcurrentTx"
+                    ]
+                },
+                "expiryDate": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "parentIdTag": {
+                    "type": "string",
+                    "maxLength": 15
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "status"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "transactionId",
+        "idTagInfo"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/StatusNotification.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/StatusNotification.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "StatusNotificationRequest",
+    "type": "object",
+    "properties": {
+        "connectorId": {
+            "type": "integer"
+        },
+        "status": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Available",
+                "Occupied",
+                "Faulted",
+                "Unavailable"
+            ]
+        },
+        "errorCode": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "ConnectorLockFailure",
+                "HighTemperature",
+                "Mode3Error",
+                "NoError",
+                "PowerMeterFailure",
+                "PowerSwitchFailure",
+                "ReaderFailure",
+                "ResetFailure"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "connectorId",
+        "status",
+        "errorCode"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/StatusNotificationResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/StatusNotificationResponse.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "StatusNotificationResponse",
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/StopTransaction.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/StopTransaction.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "StopTransactionRequest",
+    "type": "object",
+    "properties": {
+        "transactionId": {
+            "type": "integer"
+        },
+        "idTag": {
+            "type": "string",
+            "maxLength": 15
+        },
+        "timestamp": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "meterStop": {
+            "type": "integer"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "transactionId",
+        "timestamp",
+        "meterStop"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/StopTransactionResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/StopTransactionResponse.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "StopTransactionResponse",
+    "type": "object",
+    "properties": {
+        "idTagInfo": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "additionalProperties": false,
+                    "enum": [
+                        "Accepted",
+                        "Blocked",
+                        "Expired",
+                        "Invalid",
+                        "ConcurrentTx"
+                    ]
+                },
+                "expiryDate": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "parentIdTag": {
+                    "type": "string",
+                    "maxLength": 15
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "status"
+            ]
+        }
+    },
+    "additionalProperties": false
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/UnlockConnector.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/UnlockConnector.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "UnlockConnectorRequest",
+    "type": "object",
+    "properties": {
+        "connectorId": {
+            "type": "integer"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "connectorId"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/UnlockConnectorResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/UnlockConnectorResponse.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "UnlockConnectorResponse",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "Accepted",
+                "Rejected"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "status"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/UpdateFirmware.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/UpdateFirmware.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "UpdateFirmwareRequest",
+    "type": "object",
+    "properties": {
+        "retrieveDate": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "location": {
+            "type": "string"
+        },
+        "retries": {
+            "type": "integer"
+        },
+        "retryInterval": {
+            "type": "integer"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "retrieveDate",
+        "location"
+    ]
+}

--- a/ocpp-1-2-json/src/main/resources/ocpp12/UpdateFirmwareResponse.json
+++ b/ocpp-1-2-json/src/main/resources/ocpp12/UpdateFirmwareResponse.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "UpdateFirmwareResponse",
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+}

--- a/ocpp-1-2-json/src/test/kotlin/com/izivia/ocpp/json12/JsonSchemaTest.kt
+++ b/ocpp-1-2-json/src/test/kotlin/com/izivia/ocpp/json12/JsonSchemaTest.kt
@@ -1,0 +1,383 @@
+package com.izivia.ocpp.json12
+
+import com.izivia.ocpp.core12.model.authorize.AuthorizeReq
+import com.izivia.ocpp.core12.model.authorize.AuthorizeResp
+import com.izivia.ocpp.core12.model.bootnotification.BootNotificationReq
+import com.izivia.ocpp.core12.model.bootnotification.BootNotificationResp
+import com.izivia.ocpp.core12.model.bootnotification.enumeration.RegistrationStatus
+import com.izivia.ocpp.core12.model.changeavailability.ChangeAvailabilityReq
+import com.izivia.ocpp.core12.model.changeavailability.ChangeAvailabilityResp
+import com.izivia.ocpp.core12.model.changeavailability.enumeration.AvailabilityStatus
+import com.izivia.ocpp.core12.model.changeavailability.enumeration.AvailabilityType
+import com.izivia.ocpp.core12.model.changeconfiguration.ChangeConfigurationReq
+import com.izivia.ocpp.core12.model.changeconfiguration.ChangeConfigurationResp
+import com.izivia.ocpp.core12.model.changeconfiguration.enumeration.ConfigurationStatus
+import com.izivia.ocpp.core12.model.clearcache.ClearCacheReq
+import com.izivia.ocpp.core12.model.clearcache.ClearCacheResp
+import com.izivia.ocpp.core12.model.clearcache.enumeration.ClearCacheStatus
+import com.izivia.ocpp.core12.model.common.IdTagInfo
+import com.izivia.ocpp.core12.model.common.MeterValue
+import com.izivia.ocpp.core12.model.common.enumeration.AuthorizationStatus
+import com.izivia.ocpp.core12.model.common.enumeration.RemoteStartStopStatus
+import com.izivia.ocpp.core12.model.diagnosticsstatusnotification.DiagnosticsStatusNotificationReq
+import com.izivia.ocpp.core12.model.diagnosticsstatusnotification.DiagnosticsStatusNotificationResp
+import com.izivia.ocpp.core12.model.diagnosticsstatusnotification.enumeration.DiagnosticsStatus
+import com.izivia.ocpp.core12.model.firmwarestatusnotification.FirmwareStatusNotificationReq
+import com.izivia.ocpp.core12.model.firmwarestatusnotification.FirmwareStatusNotificationResp
+import com.izivia.ocpp.core12.model.firmwarestatusnotification.enumeration.FirmwareStatus
+import com.izivia.ocpp.core12.model.getdiagnostics.GetDiagnosticsReq
+import com.izivia.ocpp.core12.model.getdiagnostics.GetDiagnosticsResp
+import com.izivia.ocpp.core12.model.heartbeat.HeartbeatReq
+import com.izivia.ocpp.core12.model.heartbeat.HeartbeatResp
+import com.izivia.ocpp.core12.model.metervalues.MeterValuesReq
+import com.izivia.ocpp.core12.model.metervalues.MeterValuesResp
+import com.izivia.ocpp.core12.model.remotestart.RemoteStartTransactionReq
+import com.izivia.ocpp.core12.model.remotestart.RemoteStartTransactionResp
+import com.izivia.ocpp.core12.model.remotestop.RemoteStopTransactionReq
+import com.izivia.ocpp.core12.model.remotestop.RemoteStopTransactionResp
+import com.izivia.ocpp.core12.model.reset.ResetReq
+import com.izivia.ocpp.core12.model.reset.ResetResp
+import com.izivia.ocpp.core12.model.reset.enumeration.ResetStatus
+import com.izivia.ocpp.core12.model.reset.enumeration.ResetType
+import com.izivia.ocpp.core12.model.starttransaction.StartTransactionReq
+import com.izivia.ocpp.core12.model.starttransaction.StartTransactionResp
+import com.izivia.ocpp.core12.model.statusnotification.StatusNotificationReq
+import com.izivia.ocpp.core12.model.statusnotification.StatusNotificationResp
+import com.izivia.ocpp.core12.model.statusnotification.enumeration.ChargePointErrorCode
+import com.izivia.ocpp.core12.model.statusnotification.enumeration.ChargePointStatus
+import com.izivia.ocpp.core12.model.stoptransaction.StopTransactionReq
+import com.izivia.ocpp.core12.model.stoptransaction.StopTransactionResp
+import com.izivia.ocpp.core12.model.unlockconnector.UnlockConnectorReq
+import com.izivia.ocpp.core12.model.unlockconnector.UnlockConnectorResp
+import com.izivia.ocpp.core12.model.unlockconnector.enumeration.UnlockStatus
+import com.izivia.ocpp.core12.model.updatefirmware.UpdateFirmwareReq
+import com.izivia.ocpp.core12.model.updatefirmware.UpdateFirmwareResp
+import com.izivia.ocpp.json.JsonMessage
+import com.izivia.ocpp.json.JsonMessageType
+import kotlin.time.Instant
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isA
+
+class JsonSchemaTest {
+
+    companion object {
+        val parser = Ocpp12JsonParser()
+        val TIMESTAMP: Instant = Instant.parse("2022-02-15T00:00:00.000Z")
+    }
+
+    @Test
+    fun `authorize request format`() {
+        validateObject(AuthorizeReq(idTag = "Tag1"))
+    }
+
+    @Test
+    fun `authorize response format`() {
+        /* Required field only */
+        validateObject(AuthorizeResp(idTagInfo = IdTagInfo(status = AuthorizationStatus.Accepted)))
+
+        /* Every field */
+        validateObject(
+            AuthorizeResp(
+                idTagInfo = IdTagInfo(
+                    status = AuthorizationStatus.ConcurrentTx,
+                    expiryDate = TIMESTAMP,
+                    parentIdTag = "ParentTag1"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `bootNotification request format`() {
+        /* Required field only */
+        validateObject(BootNotificationReq(chargePointModel = "model1", chargePointVendor = "vendor1"))
+
+        /* Every field */
+        validateObject(
+            BootNotificationReq(
+                chargePointModel = "model1",
+                chargePointVendor = "vendor1",
+                chargePointSerialNumber = "SR-100",
+                chargeBoxSerialNumber = "BOX-SR-100",
+                firmwareVersion = "2.0",
+                iccid = "0",
+                imsi = "0",
+                meterSerialNumber = "SR",
+                meterType = "kW"
+            )
+        )
+    }
+
+    @Test
+    fun `bootNotification response format`() {
+        /* Required field only */
+        validateObject(BootNotificationResp(status = RegistrationStatus.Accepted))
+
+        /* Every field */
+        validateObject(
+            BootNotificationResp(
+                status = RegistrationStatus.Rejected,
+                currentTime = TIMESTAMP,
+                heartbeatInterval = 1800
+            )
+        )
+    }
+
+    @Test
+    fun `changeAvailability request format`() {
+        validateObject(ChangeAvailabilityReq(connectorId = 1, type = AvailabilityType.Operative))
+    }
+
+    @Test
+    fun `changeAvailability response format`() {
+        validateObject(ChangeAvailabilityResp(status = AvailabilityStatus.Scheduled))
+    }
+
+    @Test
+    fun `changeConfiguration request format`() {
+        validateObject(ChangeConfigurationReq(key = "HeartBeatInterval", value = "1800"))
+    }
+
+    @Test
+    fun `changeConfiguration response format`() {
+        validateObject(ChangeConfigurationResp(status = ConfigurationStatus.NotSupported))
+    }
+
+    @Test
+    fun `clearCache request format`() {
+        validateObject(ClearCacheReq())
+    }
+
+    @Test
+    fun `clearCache response format`() {
+        validateObject(ClearCacheResp(status = ClearCacheStatus.Accepted))
+    }
+
+    @Test
+    fun `diagnosticsStatusNotification request format`() {
+        validateObject(DiagnosticsStatusNotificationReq(status = DiagnosticsStatus.Uploaded))
+    }
+
+    @Test
+    fun `diagnosticsStatusNotification response format`() {
+        validateObject(DiagnosticsStatusNotificationResp())
+    }
+
+    @Test
+    fun `firmwareStatusNotification request format`() {
+        validateObject(FirmwareStatusNotificationReq(status = FirmwareStatus.Installed))
+    }
+
+    @Test
+    fun `firmwareStatusNotification response format`() {
+        validateObject(FirmwareStatusNotificationResp())
+    }
+
+    @Test
+    fun `getDiagnostics request format`() {
+        /* Required field only */
+        validateObject(GetDiagnosticsReq(location = "ftp://root:root@localhost/diagnostics"))
+
+        /* Every field */
+        validateObject(
+            GetDiagnosticsReq(
+                location = "ftp://root:root@localhost/diagnostics",
+                startTime = TIMESTAMP,
+                stopTime = TIMESTAMP,
+                retries = 3,
+                retryInterval = 60
+            )
+        )
+    }
+
+    @Test
+    fun `getDiagnostics response format`() {
+        /* Required field only */
+        validateObject(GetDiagnosticsResp())
+
+        /* Every field */
+        validateObject(GetDiagnosticsResp(fileName = "diagnostics.log"))
+    }
+
+    @Test
+    fun `heartbeat request format`() {
+        validateObject(HeartbeatReq())
+    }
+
+    @Test
+    fun `heartbeat response format`() {
+        validateObject(HeartbeatResp(currentTime = TIMESTAMP))
+    }
+
+    @Test
+    fun `meterValues request format`() {
+        /* Required field only */
+        validateObject(MeterValuesReq(connectorId = 1))
+
+        /* Every field */
+        validateObject(
+            MeterValuesReq(
+                connectorId = 1,
+                values = listOf(MeterValue(timestamp = TIMESTAMP, value = 123456789))
+            )
+        )
+    }
+
+    @Test
+    fun `meterValues response format`() {
+        validateObject(MeterValuesResp())
+    }
+
+    @Test
+    fun `remoteStartTransaction request format`() {
+        validateObject(RemoteStartTransactionReq(idTag = "Tag1"))
+    }
+
+    @Test
+    fun `remoteStartTransaction response format`() {
+        validateObject(RemoteStartTransactionResp(status = RemoteStartStopStatus.Accepted))
+    }
+
+    @Test
+    fun `remoteStopTransaction request format`() {
+        validateObject(RemoteStopTransactionReq(transactionId = 1))
+    }
+
+    @Test
+    fun `remoteStopTransaction response format`() {
+        validateObject(RemoteStopTransactionResp(status = RemoteStartStopStatus.Rejected))
+    }
+
+    @Test
+    fun `reset request format`() {
+        validateObject(ResetReq(type = ResetType.Hard))
+    }
+
+    @Test
+    fun `reset response format`() {
+        validateObject(ResetResp(status = ResetStatus.Accepted))
+    }
+
+    @Test
+    fun `startTransaction request format`() {
+        validateObject(
+            StartTransactionReq(
+                connectorId = 1,
+                idTag = "Tag1",
+                meterStart = 0,
+                timestamp = TIMESTAMP
+            )
+        )
+    }
+
+    @Test
+    fun `startTransaction response format`() {
+        validateObject(
+            StartTransactionResp(
+                transactionId = 1,
+                idTagInfo = IdTagInfo(status = AuthorizationStatus.Accepted)
+            )
+        )
+    }
+
+    @Test
+    fun `statusNotification request format`() {
+        validateObject(
+            StatusNotificationReq(
+                connectorId = 1,
+                status = ChargePointStatus.Occupied,
+                errorCode = ChargePointErrorCode.NoError
+            )
+        )
+    }
+
+    @Test
+    fun `statusNotification response format`() {
+        validateObject(StatusNotificationResp())
+    }
+
+    @Test
+    fun `stopTransaction request format`() {
+        /* Required field only */
+        validateObject(
+            StopTransactionReq(
+                transactionId = 1,
+                timestamp = TIMESTAMP,
+                meterStop = 1000
+            )
+        )
+
+        /* Every field */
+        validateObject(
+            StopTransactionReq(
+                transactionId = 1,
+                idTag = "Tag1",
+                timestamp = TIMESTAMP,
+                meterStop = 1000
+            )
+        )
+    }
+
+    @Test
+    fun `stopTransaction response format`() {
+        /* Required field only */
+        validateObject(StopTransactionResp())
+
+        /* Every field */
+        validateObject(StopTransactionResp(idTagInfo = IdTagInfo(status = AuthorizationStatus.Expired)))
+    }
+
+    @Test
+    fun `unlockConnector request format`() {
+        validateObject(UnlockConnectorReq(connectorId = 1))
+    }
+
+    @Test
+    fun `unlockConnector response format`() {
+        validateObject(UnlockConnectorResp(status = UnlockStatus.Accepted))
+    }
+
+    @Test
+    fun `updateFirmware request format`() {
+        /* Required field only */
+        validateObject(
+            UpdateFirmwareReq(
+                location = "ftp://root:root@localhost/firmware.bin",
+                retrieveDate = TIMESTAMP
+            )
+        )
+
+        /* Every field */
+        validateObject(
+            UpdateFirmwareReq(
+                location = "ftp://root:root@localhost/firmware.bin",
+                retrieveDate = TIMESTAMP,
+                retries = 3,
+                retryInterval = 60
+            )
+        )
+    }
+
+    @Test
+    fun `updateFirmware response format`() {
+        validateObject(UpdateFirmwareResp())
+    }
+
+    inline fun <reified T : Any> validateObject(instance: T) {
+        val instanceClass = instance::class.java.simpleName
+        expectThat(
+            parser.parseAnyFromJson<T>(
+                parser.mapToJson(
+                    JsonMessage(
+                        msgType = JsonMessageType.CALL.takeIf { instanceClass.endsWith("Req") }
+                            ?: JsonMessageType.CALL_RESULT,
+                        msgId = "123456",
+                        action = instanceClass.replace(Regex("Req$"), "").replace(Regex("Resp$"), ""),
+                        payload = instance
+                    )
+                )
+            )
+        ).isA<JsonMessage<T>>().get { payload }.isA<T>()
+    }
+}

--- a/ocpp-1-2-json/src/test/kotlin/com/izivia/ocpp/json12/Ocpp12JsonParserErrorTest.kt
+++ b/ocpp-1-2-json/src/test/kotlin/com/izivia/ocpp/json12/Ocpp12JsonParserErrorTest.kt
@@ -1,0 +1,311 @@
+package com.izivia.ocpp.json12
+
+import com.izivia.ocpp.core12.Ocpp12ForcedFieldType
+import com.izivia.ocpp.core12.model.bootnotification.BootNotificationResp
+import com.izivia.ocpp.core12.model.bootnotification.enumeration.RegistrationStatus
+import com.izivia.ocpp.core12.model.changeconfiguration.ChangeConfigurationReq
+import com.izivia.ocpp.core12.model.common.enumeration.Actions
+import com.izivia.ocpp.core12.model.statusnotification.StatusNotificationReq
+import com.izivia.ocpp.utils.ActionTypeEnum
+import com.izivia.ocpp.utils.ErrorDetailCode
+import com.izivia.ocpp.utils.MessageErrorCode
+import com.izivia.ocpp.utils.TypeConvertEnum
+import com.izivia.ocpp.utils.fault.Fault
+import com.networknt.schema.ValidatorTypeCode
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.*
+
+class Ocpp12JsonParserErrorTest {
+
+    companion object {
+        val parser = Ocpp12JsonParser()
+    }
+
+    @Test
+    fun `should parse Heartbeat request`() {
+        val request = """[2,"messageId","Heartbeat",{}]"""
+
+        expectThat(parser.parseAnyFromString(request))
+            .get { action }.isEqualTo("Heartbeat")
+    }
+
+    @Test
+    fun `should parse to Fault PROTOCOL_ERROR inconsistent request`() {
+        val request = """[2,"messageId","StartTransaction",{"meterStart": 0,
+            |"timestamp": "2022-08-03T11:00:01.916Z", "idTag": "idTag"}]
+        """.trimMargin()
+
+        expectThat(parser.parseAnyFromString(request))
+            .and {
+                get { action }.isEqualTo("Fault")
+                get { errorCode }.isEqualTo(MessageErrorCode.PROTOCOL_ERROR)
+                get { payload }.isA<Fault>()
+                    .get { errorDetails }
+                    .any {
+                        get { code }.isEqualTo(ValidatorTypeCode.REQUIRED.errorCode)
+                        get { detail }.contains("Validations error")
+                    }
+            }
+    }
+
+    @Test
+    fun `should parse to Fault MESSAGE_TYPE_NOT_SUPPORTED inconsistent request`() {
+        val request = """[15,"messageId","Heartbeat",{}]"""
+
+        expectThat(parser.parseAnyFromString(request))
+            .and {
+                get { action }.isEqualTo("Fault")
+                get { errorCode }.isEqualTo(MessageErrorCode.MESSAGE_TYPE_NOT_SUPPORTED)
+                get { payload }.isA<Fault>()
+                    .get { errorDetails }.hasSize(1)
+                    .and {
+                        get { get(0) }.and {
+                            get { code }.isEqualTo(ErrorDetailCode.PAYLOAD.value)
+                            get { detail }.isEqualTo(request)
+                        }
+                    }
+            }
+    }
+
+    @Test
+    fun `should parse to Fault NOT_IMPLEMENTED inconsistent request`() {
+        // DataTransfer exists in OCPP 1.5 but not in 1.2.
+        val request = """[2,"messageId","DataTransfer",{"vendorId":"vendor1"}]"""
+
+        expectThat(parser.parseAnyFromString(request))
+            .and {
+                get { action }.isEqualTo("Fault")
+                get { errorCode }.isEqualTo(MessageErrorCode.NOT_IMPLEMENTED)
+                get { payload }.isA<Fault>()
+                    .get { errorDetails }
+                    .any {
+                        get { code }.isEqualTo(ErrorDetailCode.ACTION.value)
+                        get { detail }.isEqualTo("DataTransfer")
+                    }
+            }
+    }
+
+    @Test
+    fun `should parse to Fault FORMAT_VIOLATION inconsistent request`() {
+        val request = """{"Json": "Ok", "Ocpp": "not}"""
+
+        expectThat(parser.parseAnyFromString(request))
+            .and {
+                get { action }.isEqualTo("Fault")
+                get { errorCode }.isEqualTo(MessageErrorCode.FORMAT_VIOLATION)
+                get { payload }.isA<Fault>()
+                    .get { errorDetails }.hasSize(1)
+                    .and {
+                        get { get(0) }.and {
+                            get { code }.isEqualTo(ErrorDetailCode.PAYLOAD.value)
+                            get { detail }.isEqualTo(request)
+                        }
+                    }
+            }
+    }
+
+    @Test
+    fun `should parse to Fault missing usedClazz`() {
+        val response = """[3,"messageId",{}]"""
+
+        expectThat(parser.parseAnyFromString(response))
+            .and {
+                get { action }.isEqualTo("Fault")
+                get { errorCode }.isEqualTo(MessageErrorCode.NOT_IMPLEMENTED)
+                get { payload }.isA<Fault>()
+                    .get { errorDetails }
+                    .any {
+                        get { code }.isEqualTo(ErrorDetailCode.ACTION.value)
+                        get { detail }
+                            .contains("class used to retrieve the response action is not defined")
+                    }
+            }
+    }
+
+    @Test
+    fun `should parse to Fault BOOTNOT inconsistent request`() {
+        val request = """[2,"messageId","BootNotification",
+            {"chargePointModel": "testModel", "chargePointVendor": "testVendor",
+            "chargePointSerialNumber":"1234567891011121314151617181920"}]
+        """.trimMargin()
+
+        expectThat(parser.parseAnyFromString(request))
+            .and {
+                get { action }.isEqualTo("Fault")
+                get { errorCode }.isEqualTo(MessageErrorCode.PROTOCOL_ERROR)
+                get { payload }.isA<Fault>()
+                    .get { errorDetails }
+                    .any {
+                        get { code }.isEqualTo(ValidatorTypeCode.MAX_LENGTH.errorCode)
+                        get { detail }.contains("Validations error")
+                    }
+            }
+    }
+
+    @Test
+    fun `should parse to BootNotification on ignoring 1013 inconsistent request`() {
+        val ocppIgnore1013 = Ocpp12JsonParser(ignoredValidationCodes = listOf(ValidatorTypeCode.MAX_LENGTH))
+
+        val request = """[2,"messageId","BootNotification",
+            {"chargePointModel": "testModel", "chargePointVendor": "testVendor",
+            "chargePointSerialNumber":"1234567891011121314151617181920"}]
+        """.trimMargin()
+
+        expectThat(ocppIgnore1013.parseAnyFromString(request))
+            .and {
+                get { action }.isEqualTo("BootNotification")
+                get { warnings }.isNotNull().hasSize(1)
+            }
+    }
+
+    @Test
+    fun `should parse to BootNotification on ignoring additional properties request`() {
+        val ocppIgnore = Ocpp12JsonParser(ignoredValidationCodes = listOf(ValidatorTypeCode.ADDITIONAL_PROPERTIES))
+
+        val request = """[2,"messageId","BootNotification",
+            {"chargePointModel": "testModel", "chargePointVendor": "testVendor",
+            "chargePointSerialNumber":"12345678910", "additional": "Properties"}]
+        """.trimMargin()
+
+        expectThat(ocppIgnore.parseAnyFromString(request))
+            .and {
+                get { action }.isEqualTo("BootNotification")
+                get { warnings }.isNotNull().hasSize(1)
+            }
+    }
+
+    /* The schemas must be narrower than the OCPP 1.5 ones: every payload below is valid in 1.5. */
+
+    @Test
+    fun `should reject the 1-5 only Reserved charge point status`() {
+        val request = """[2,"messageId","StatusNotification",
+            {"connectorId": 1, "status": "Reserved", "errorCode": "NoError"}]
+        """.trimMargin()
+
+        expectRejectedWith(request, ValidatorTypeCode.ENUM)
+    }
+
+    @Test
+    fun `should reject the 1-5 only GroundFailure error code`() {
+        val request = """[2,"messageId","StatusNotification",
+            {"connectorId": 1, "status": "Available", "errorCode": "GroundFailure"}]
+        """.trimMargin()
+
+        expectRejectedWith(request, ValidatorTypeCode.ENUM)
+    }
+
+    @Test
+    fun `should reject the 1-5 only statusNotification fields`() {
+        val request = """[2,"messageId","StatusNotification",
+            {"connectorId": 1, "status": "Available", "errorCode": "NoError",
+            "timestamp": "2022-02-15T00:00:00.000Z", "info": "Charging", "vendorId": "vendor1"}]
+        """.trimMargin()
+
+        expectRejectedWith(request, ValidatorTypeCode.ADDITIONAL_PROPERTIES)
+    }
+
+    @Test
+    fun `should reject a stopTransaction idTag longer than the 1-2 limit`() {
+        // 18 characters: within the 1.5 limit of 20, over the 1.2 limit of 15.
+        val overLimit = stopTransactionWith(idTag = "012345678901234567")
+        val atLimit = stopTransactionWith(idTag = "012345678901234")
+
+        expectRejectedWith(overLimit, ValidatorTypeCode.MAX_LENGTH)
+        expectThat(parser.parseAnyFromString(atLimit)).get { action }.isEqualTo("StopTransaction")
+    }
+
+    @Test
+    fun `should reject the 1-5 sampled value shape in meterValues`() {
+        val request = """[2,"messageId","MeterValues",
+            {"connectorId": 1, "values": [{"timestamp": "2022-02-15T00:00:00.000Z",
+            "value": [{"value": "123456789", "unit": "Wh"}]}]}]
+        """.trimMargin()
+
+        expectRejectedWith(request, ValidatorTypeCode.TYPE)
+    }
+
+    @Test
+    fun `should accept a bootNotification response carrying only a status`() {
+        // currentTime and heartbeatInterval are mandatory in 1.5 but optional in 1.2: this fails if the
+        // 1.5 schema is picked up from the classpath instead of the 1.2 one.
+        val response = """[3,"messageId",{"status":"Accepted"}]"""
+
+        expectThat(parser.parseAnyFromJson<BootNotificationResp>(response))
+            .and {
+                get { action }.isEqualTo("bootNotification")
+                get { payload }.isA<BootNotificationResp>()
+                    .and {
+                        get { status }.isEqualTo(RegistrationStatus.Accepted)
+                        get { currentTime }.isNull()
+                        get { heartbeatInterval }.isNull()
+                    }
+            }
+    }
+
+    @Test
+    fun `should skip validation when it is disabled`() {
+        // Carries the 1.5-only fields, which the 1.2 schema rejects but Jackson simply ignores.
+        val request = """[2,"messageId","StatusNotification",
+            {"connectorId": 1, "status": "Available", "errorCode": "NoError",
+            "timestamp": "2022-02-15T00:00:00.000Z", "info": "Charging"}]
+        """.trimMargin()
+
+        expectThat(parser.parseAnyFromString(request)).get { action }.isEqualTo("Fault")
+        expectThat(Ocpp12JsonParser(enableValidation = false).parseAnyFromString(request))
+            .and {
+                get { action }.isEqualTo("StatusNotification")
+                get { payload }.isA<StatusNotificationReq>().get { connectorId }.isEqualTo(1)
+            }
+    }
+
+    @Test
+    fun `should parse a changeConfiguration with a non string value`() {
+        val ocppParser = Ocpp12JsonParser(
+            enableValidation = false,
+            forcedFieldTypes = listOf(
+                Ocpp12ForcedFieldType(
+                    action = Actions.CHANGECONFIGURATION,
+                    actionType = ActionTypeEnum.REQUEST,
+                    fieldPath = "value",
+                    typeRequested = TypeConvertEnum.STRING
+                )
+            )
+        )
+
+        val request = """[2,"messageId","ChangeConfiguration",{"key":"HeartBeatInterval","value":1800}]"""
+
+        expectThat(ocppParser.parseAnyFromString(request)).and {
+            get { action }.isEqualTo(Actions.CHANGECONFIGURATION.camelCase())
+            get { payload }.isA<ChangeConfigurationReq>().get { value }.isEqualTo("1800")
+            get { warnings }
+                .isNotNull()
+                .hasSize(1)
+                .and {
+                    get { get(0) }.and {
+                        get { code }.isEqualTo(ErrorDetailCode.CONVERT_FIELD_REPLACED.value)
+                        get { detail }.contains("[value] converted to STRING")
+                    }
+                }
+        }
+    }
+
+    private fun stopTransactionWith(idTag: String) =
+        """[2,"messageId","StopTransaction",{"transactionId": 1, "idTag": "$idTag",
+            "timestamp": "2022-02-15T00:00:00.000Z", "meterStop": 1000}]
+        """.trimMargin()
+
+    private fun expectRejectedWith(request: String, expectedCode: ValidatorTypeCode) {
+        expectThat(parser.parseAnyFromString(request))
+            .and {
+                get { action }.isEqualTo("Fault")
+                get { errorCode }.isEqualTo(MessageErrorCode.PROTOCOL_ERROR)
+                get { payload }.isA<Fault>()
+                    .get { errorDetails }
+                    .any {
+                        get { code }.isEqualTo(expectedCode.errorCode)
+                        get { detail }.contains("Validations error")
+                    }
+            }
+    }
+}

--- a/ocpp-json/src/main/kotlin/com/izivia/ocpp/json/OcppJsonValidator.kt
+++ b/ocpp-json/src/main/kotlin/com/izivia/ocpp/json/OcppJsonValidator.kt
@@ -9,8 +9,16 @@ import com.networknt.schema.ValidationMessage
 import java.io.InputStream
 import java.util.Locale
 
-class OcppJsonValidator(
-    private val specVersion: SpecVersion.VersionFlag
+/**
+ * Loads and caches the JSON schemas of a single OCPP version.
+ *
+ * Schemas are resolved as classpath resources by action name. Since every version module ships its
+ * own schemas under the same names, [schemaFolder] lets a module namespace them; the default keeps
+ * them at the resources root.
+ */
+class OcppJsonValidator @JvmOverloads constructor(
+    private val specVersion: SpecVersion.VersionFlag,
+    private val schemaFolder: String = ""
 ) {
     private val jsonSchemas = mutableMapOf<String, JsonSchema>()
 
@@ -20,7 +28,8 @@ class OcppJsonValidator(
     private val config: SchemaValidatorsConfig =
         SchemaValidatorsConfig.builder().locale(Locale.ENGLISH).build()
 
-    private fun getJsonSchema(file: String): JsonSchema {
+    private fun getJsonSchema(action: String): JsonSchema {
+        val file = if (schemaFolder.isEmpty()) "$action.json" else "$schemaFolder/$action.json"
         val factory: JsonSchemaFactory = JsonSchemaFactory.getInstance(specVersion)
         val input: InputStream? = Thread.currentThread().contextClassLoader.getResourceAsStream(file)
         return factory.getSchema(input, config)
@@ -32,7 +41,7 @@ class OcppJsonValidator(
      */
     fun isValidObject(action: String, payload: JsonNode): List<ValidationMessage> =
         // Info :  loading JsonSchema is not thread safe. Can affect performance during the first instanciation
-        (jsonSchemas[action] ?: getJsonSchema("$action.json").also { jsonSchemas[action] = it })
+        (jsonSchemas[action] ?: getJsonSchema(action).also { jsonSchemas[action] = it })
             .validate(payload)
             .toList()
 }

--- a/ocpp-transport-websocket/build.gradle.kts
+++ b/ocpp-transport-websocket/build.gradle.kts
@@ -16,9 +16,11 @@ dependencies {
     implementation(project(":ocpp-2-0-core"))
     implementation(project(":ocpp-1-6-core"))
     implementation(project(":ocpp-1-5-core"))
+    implementation(project(":ocpp-1-2-core"))
     implementation(project(":ocpp-2-0-json"))
     implementation(project(":ocpp-1-6-json"))
     implementation(project(":ocpp-1-5-json"))
+    implementation(project(":ocpp-1-2-json"))
 }
 
 java {

--- a/ocpp-transport-websocket/src/main/kotlin/com/izivia/ocpp/websocket/Utils.kt
+++ b/ocpp-transport-websocket/src/main/kotlin/com/izivia/ocpp/websocket/Utils.kt
@@ -2,16 +2,18 @@ package com.izivia.ocpp.websocket
 
 import com.izivia.ocpp.OcppVersion
 import com.izivia.ocpp.json.OcppJsonParser
+import com.izivia.ocpp.json12.Ocpp12JsonParser
 import com.izivia.ocpp.json15.Ocpp15JsonParser
 import com.izivia.ocpp.json16.Ocpp16JsonParser
 import com.izivia.ocpp.json20.Ocpp20JsonParser
 import com.izivia.ocpp.transport.OcppCallErrorPayload
 
+// Exhaustive on purpose: a new OCPP version must fail to compile here rather than at runtime.
 internal fun getJsonMapper(ocppVersion: OcppVersion) = when (ocppVersion) {
+    OcppVersion.OCPP_1_2 -> Ocpp12JsonParser()
     OcppVersion.OCPP_1_5 -> Ocpp15JsonParser()
     OcppVersion.OCPP_1_6 -> Ocpp16JsonParser()
     OcppVersion.OCPP_2_0 -> Ocpp20JsonParser()
-    else -> throw IllegalStateException("Websocket transport is not supported by the ocpp version 1.5")
 }
 
 internal fun OcppCallErrorPayload.toJson(parser: OcppJsonParser) = parser.mapPayloadToString(this.exception)

--- a/ocpp-transport-websocket/src/test/kotlin/com/izivia/ocpp/websocket/test/OcppVersionBridgeTest.kt
+++ b/ocpp-transport-websocket/src/test/kotlin/com/izivia/ocpp/websocket/test/OcppVersionBridgeTest.kt
@@ -1,0 +1,27 @@
+package com.izivia.ocpp.websocket.test
+
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import com.izivia.ocpp.OcppVersion as OcppVersionWamp
+import com.izivia.ocpp.transport.OcppVersion as OcppVersionTransport
+
+/**
+ * `WebsocketServer` bridges the transport and WAMP version enums with `OcppVersionWamp.valueOf(name)`,
+ * a match nothing else checks. These tests fail on a divergence instead of letting it surface as an
+ * `IllegalArgumentException` inside a WebSocket handler.
+ */
+class OcppVersionBridgeTest {
+
+    @Test
+    fun `both version enums declare the same constants`() {
+        expectThat(OcppVersionWamp.entries.map { it.name })
+            .isEqualTo(OcppVersionTransport.entries.map { it.name })
+    }
+
+    @Test
+    fun `both version enums declare the same subprotocols`() {
+        expectThat(OcppVersionWamp.entries.associate { it.name to it.subprotocol })
+            .isEqualTo(OcppVersionTransport.entries.associate { it.name to it.subprotocol })
+    }
+}

--- a/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/Ocpp.kt
+++ b/ocpp-wamp/src/main/kotlin/com/izivia/ocpp/Ocpp.kt
@@ -3,5 +3,5 @@ package com.izivia.ocpp
 typealias CSOcppId = String
 
 enum class OcppVersion(val subprotocol:String) {
-    OCPP_1_5("ocpp1.5"), OCPP_1_6("ocpp1.6"), OCPP_2_0("ocpp2.0.1")
+    OCPP_1_2("ocpp1.2"), OCPP_1_5("ocpp1.5"), OCPP_1_6("ocpp1.6"), OCPP_2_0("ocpp2.0.1")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,7 @@ include(
     "ocpp-1-5-api",
     "ocpp-1-2-api-adapter",
     "ocpp-1-2-core",
+    "ocpp-1-2-json",
     "ocpp-1-2-soap",
     "ocpp-1-2-api",
     "ocpp-transport-soap",

--- a/toolkit/src/main/kotlin/com/izivia/ocpp/integration/ApiFactory.kt
+++ b/toolkit/src/main/kotlin/com/izivia/ocpp/integration/ApiFactory.kt
@@ -115,11 +115,7 @@ class ApiFactory {
             newMessageId: () -> String,
             settings: OcppWampServerSettings,
             listeners: EventsListeners = EventsListeners()
-        ): ServerTransport {
-            // Fail fast with an actionable message rather than on the valueOf inside WebsocketServer.
-            ocppVersion.forEach { getWampVersion(it) }
-            return WebsocketServer(ocppVersion, path, newMessageId, settings, listeners)
-        }
+        ): ServerTransport = WebsocketServer(ocppVersion, path, newMessageId, settings, listeners)
 
         private fun createServerTransportSoap(
             path: String,
@@ -282,19 +278,20 @@ class ApiFactory {
 }
 
 /**
- * Maps a transport version onto the WAMP subprotocol enum, mirroring [getSoapParser]. Exhaustive so a
- * version without a WebSocket binding reports what is wrong instead of failing on a `No enum constant`.
+ * Maps a transport version onto the WAMP subprotocol enum, mirroring [getSoapParser]. Exhaustive so
+ * that a transport version added without a WebSocket counterpart fails to compile here, rather than
+ * on the `valueOf` by name that `WebsocketServer` performs.
  */
 private fun getWampVersion(version: OcppVersionTransport): OcppVersion = when (version) {
+    OcppVersionTransport.OCPP_2_0 -> OcppVersion.OCPP_2_0
     OcppVersionTransport.OCPP_1_6 -> OcppVersion.OCPP_1_6
     OcppVersionTransport.OCPP_1_5 -> OcppVersion.OCPP_1_5
-    OcppVersionTransport.OCPP_2_0 -> OcppVersion.OCPP_2_0
-    OcppVersionTransport.OCPP_1_2 -> throw IllegalArgumentException("OCPP 1.2 has no WebSocket transport")
+    OcppVersionTransport.OCPP_1_2 -> OcppVersion.OCPP_1_2
 }
 
 private fun getSoapParser(version: OcppVersionTransport) = when (version) {
+    OcppVersionTransport.OCPP_2_0 -> throw IllegalArgumentException("OCPP 2.0 has no SOAP transport")
     OcppVersionTransport.OCPP_1_6 -> Ocpp16SoapParser()
     OcppVersionTransport.OCPP_1_5 -> Ocpp15SoapParser()
     OcppVersionTransport.OCPP_1_2 -> Ocpp12SoapParser()
-    OcppVersionTransport.OCPP_2_0 -> throw IllegalArgumentException("OCPP 2.0 has no SOAP transport")
 }

--- a/toolkit/src/test/kotlin/com/izivia/ocpp/integration/test/Ocpp12FactoryTest.kt
+++ b/toolkit/src/test/kotlin/com/izivia/ocpp/integration/test/Ocpp12FactoryTest.kt
@@ -12,16 +12,27 @@ import com.izivia.ocpp.integration.model.ServerSetting
 import com.izivia.ocpp.integration.model.Settings
 import com.izivia.ocpp.integration.model.TransportEnum
 import com.izivia.ocpp.operation.information.ChargingStationConfig
+import com.izivia.ocpp.operation.information.ExecutionMetadata
+import com.izivia.ocpp.operation.information.OperationExecution
 import com.izivia.ocpp.operation.information.RequestMetadata
+import com.izivia.ocpp.operation.information.RequestStatus
 import com.izivia.ocpp.soap12.Ocpp12SoapParser
 import com.izivia.ocpp.transport.OcppVersion
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import strikt.api.expectThat
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
+import java.net.ServerSocket
+import com.izivia.ocpp.core12.model.authorize.AuthorizeReq as AuthorizeReq12
+import com.izivia.ocpp.core12.model.authorize.AuthorizeResp as AuthorizeResp12
+import com.izivia.ocpp.core12.model.common.IdTagInfo as IdTagInfo12
+import com.izivia.ocpp.core12.model.common.enumeration.AuthorizationStatus as AuthorizationStatus12
+import com.izivia.ocpp.core12.model.common.enumeration.RemoteStartStopStatus as RemoteStartStopStatus12
 import com.izivia.ocpp.core12.model.heartbeat.HeartbeatResp as HeartbeatResp12
+import com.izivia.ocpp.core12.model.remotestart.RemoteStartTransactionReq as RemoteStartTransactionReq12
+import com.izivia.ocpp.core12.model.remotestart.RemoteStartTransactionResp as RemoteStartTransactionResp12
 
 class Ocpp12FactoryTest {
     @Test
@@ -108,41 +119,112 @@ class Ocpp12FactoryTest {
     }
 
     @Test
-    fun `rejects OCPP 1-2 over websocket with an actionable message`() {
-        val error = assertThrows<IllegalArgumentException> {
-            ApiFactory.getCSMSApi(
-                settings = Settings(
-                    ocppVersion = OcppVersion.OCPP_1_2,
-                    transportType = TransportEnum.WEBSOCKET,
-                    target = "ws://localhost:8080/ocpp"
-                ),
-                ocppId = "CP001",
-                csApi = mockk<CSApi>(relaxed = true)
-            )
-        }
+    fun `creates generic API adapter for OCPP 1-2 over websocket`() {
+        val api = ApiFactory.getCSMSApi(
+            settings = Settings(
+                ocppVersion = OcppVersion.OCPP_1_2,
+                transportType = TransportEnum.WEBSOCKET,
+                target = "ws://localhost:8080/ocpp"
+            ),
+            ocppId = "CP001",
+            csApi = mockk<CSApi>(relaxed = true)
+        )
 
-        expectThat(error.message).isEqualTo("OCPP 1.2 has no WebSocket transport")
+        expectThat(api).isA<Ocpp12Adapter>()
     }
 
     @Test
-    fun `rejects an OCPP 1-2 websocket server with an actionable message`() {
-        val error = assertThrows<IllegalArgumentException> {
-            ApiFactory.csmsOcppServer(
-                csmsSettings = CSMSSettings(
-                    listOf(
-                        ServerSetting(
-                            port = 0,
-                            path = "/ocpp",
-                            ocppVersion = setOf(OcppVersion.OCPP_1_2),
-                            transportType = TransportEnum.WEBSOCKET
-                        )
+    fun `creates CSMS API for OCPP 1-2 websocket server`() {
+        val csms = ApiFactory.csmsOcppServer(
+            csmsSettings = CSMSSettings(
+                listOf(
+                    ServerSetting(
+                        port = 0,
+                        path = "/ocpp",
+                        ocppVersion = setOf(OcppVersion.OCPP_1_2),
+                        transportType = TransportEnum.WEBSOCKET
                     )
-                ),
-                csmsApiCallbacks = listOf(mockk<ChargePointOperations>(relaxed = true)),
-                fn = { ChargingStationConfig(acceptConnection = true, soapUrl = null) }
+                )
+            ),
+            csmsApiCallbacks = listOf(mockk<ChargePointOperations>(relaxed = true)),
+            fn = { ChargingStationConfig(acceptConnection = true, soapUrl = null) }
+        )
+
+        expectThat(csms.getCSApi12()).isA<CSMSOperations>()
+    }
+
+    @Test
+    fun `exchanges OCPP 1-2 messages over a websocket connection`() {
+        val port = ServerSocket(0).use { it.localPort }
+        val path = "ws"
+        val chargePointId = "CP001"
+        val idTag = "Tag1"
+
+        val server = ApiFactory.csmsOcppServer(
+            csmsSettings = CSMSSettings(
+                listOf(
+                    ServerSetting(
+                        port = port,
+                        path = path,
+                        ocppVersion = setOf(OcppVersion.OCPP_1_2),
+                        transportType = TransportEnum.WEBSOCKET
+                    )
+                )
+            ),
+            csmsApiCallbacks = listOf(authorizingCsms(idTag)),
+            fn = { ChargingStationConfig(acceptConnection = true, soapUrl = null) }
+        )
+        server.start()
+
+        try {
+            val connection = ApiFactory.ocpp12ConnectionToCSMS(
+                chargePointId = chargePointId,
+                csmsUrl = "ws://localhost:$port/$path",
+                transportType = TransportEnum.WEBSOCKET,
+                clientPath = null,
+                clientPort = null,
+                ocppCSCallbacks = object : OcppCSCallbacks {
+                    override fun remoteStartTransaction(req: RemoteStartTransactionReq12) =
+                        RemoteStartTransactionResp12(RemoteStartStopStatus12.Accepted)
+                }
+            )
+            connection.connect()
+
+            try {
+                /* Charge point to central system */
+                val authorize = connection
+                    .authorize(RequestMetadata(chargePointId), AuthorizeReq12(idTag = idTag))
+                    .response
+                expectThat(authorize.idTagInfo.status).isEqualTo(AuthorizationStatus12.Accepted)
+
+                /* Central system to charge point */
+                val remoteStart = server.getCSApi12()
+                    .remoteStartTransaction(
+                        RequestMetadata(chargePointId),
+                        RemoteStartTransactionReq12(idTag = idTag)
+                    )
+                    .response
+                expectThat(remoteStart.status).isEqualTo(RemoteStartStopStatus12.Accepted)
+            } finally {
+                connection.close()
+            }
+        } finally {
+            server.stop()
+        }
+    }
+
+    /**
+     * Central system side of the websocket round trip. Only [ChargePointOperations.authorize] is
+     * stubbed, and only for [acceptedIdTag]: any other call fails the test instead of answering
+     * silently.
+     */
+    private fun authorizingCsms(acceptedIdTag: String) = mockk<ChargePointOperations>().also { csms ->
+        every { csms.authorize(any(), match { it.idTag == acceptedIdTag }) } answers {
+            OperationExecution(
+                ExecutionMetadata(firstArg(), RequestStatus.SUCCESS),
+                secondArg(),
+                AuthorizeResp12(idTagInfo = IdTagInfo12(status = AuthorizationStatus12.Accepted))
             )
         }
-
-        expectThat(error.message).isEqualTo("OCPP 1.2 has no WebSocket transport")
     }
 }


### PR DESCRIPTION
Refs #84, which #98 closed by adding OCPP 1.2 over SOAP. This completes 1.2 with the JSON/WebSocket transport.

## Summary

OCPP 1.2 was assumed to be SOAP-only, but that is an implementation gap rather than a protocol one. The OCPP-J specification defines the JSON/WebSocket transport independently of message content and lists `ocpp1.2` among the registered WebSocket subprotocols, alongside `ocpp1.5`, `ocpp1.6` and `ocpp2.0`. The toolkit already shipped `ocpp-1-5-json`; it simply had no 1.2 counterpart, so `ApiFactory` rejected the combination outright.

This adds `ocpp-1-2-json` and wires it through the WebSocket transport, so a 1.2 charge point connects end to end, and corrects the README, which claimed 1.2 had no WebSocket binding.

## What's included

- **`ocpp-1-2-json`** (`com.izivia.ocpp.json12`): `Ocpp12JsonParser` and `Ocpp12JsonObjectMapper`, mirroring `ocpp-1-5-json`, plus the 36 JSON schemas for the 18 OCPP 1.2 messages.
- **Wiring**: `OcppVersion` gains `OCPP_1_2("ocpp1.2")`, `getJsonMapper` routes it to `Ocpp12JsonParser`, and `ApiFactory.getWampVersion` maps it instead of throwing.

## The schemas

OCPP 1.2 has no official OCPP-J schema set, so the 36 schemas are derived from the OCPP 1.2 WSDL, with the string lengths taken from the specification (the WSDL declares none). They are **not** copies of the 1.5 schemas — 1.2 is systematically narrower:

| | OCPP 1.2 | OCPP 1.5 |
|---|---|---|
| `ChargePointStatus` | 4 values (no `Reserved`) | 5 values |
| `ChargePointErrorCode` | 8 values | 13 values |
| `StatusNotification.req` | 3 properties | 7 properties |
| `MeterValue.value` | a single integer | a `SampledValue` list |
| `BootNotification.conf` | only `status` required | `status`, `currentTime`, `heartbeatInterval` required |
| `idTag` | `maxLength` 15 | `maxLength` 20 |

Where the WSDL and the specification PDF disagree — the PDF adds an optional `connectorId` to `RemoteStartTransaction.req` — the WSDL wins, which is also what the existing `ocpp-1-2-core` model does.

## Schemas live in an `ocpp12` resource folder

`OcppJsonValidator` resolves schemas by bare file name off the classpath. `ocpp-1-5-json` ships `<Action>.json` / `<Action>Response.json` at the resources root while `ocpp-1-6-json` and `ocpp-2-0-json` ship `<Action>Request.json` / `<Action>Response.json`, so the `*Response.json` names already shadow each other today — and `toolkit` depends on all of them.

Without a namespace, a 1.2 payload could therefore be validated against the 1.5 schema, which is not hypothetical: 1.5's `BootNotificationResponse.json` requires `currentTime` and `heartbeatInterval`, both optional in 1.2.

So `OcppJsonValidator` gains an optional `schemaFolder`, and `ocpp-1-2-json` ships its resources under `ocpp12/`. The parameter defaults to the resources root, so 1.5, 1.6 and 2.0 are byte-for-byte unchanged, and `@JvmOverloads` keeps the single-argument constructor in the published artifact. `Ocpp12JsonParser.validateJson` is then identical to its 1.5 counterpart.

**The pre-existing collision between 1.5, 1.6 and 2.0 is left as is — tracked by #111, which confirms it already misvalidates 2.0.1 payloads against the 1.6 schemas on `dev`. The mechanism to fix it now exists; moving their resources belongs in that change.**

## Drive-by fix

`getJsonMapper`'s `else` branch threw `"Websocket transport is not supported by the ocpp version 1.5"` while 1.5 was supported on the line above. The `when` is now exhaustive over `OcppVersion`, so a future version fails to compile here instead of reporting the wrong thing at runtime.

`ApiFactory.createServerTransportWebsocket` guarded against a version with no WebSocket binding by calling `getWampVersion` for its side effect. Every version maps now, so that guard can no longer fire; it is replaced by a test asserting that the transport and WAMP `OcppVersion` enums stay in step — the match `WebsocketServer` relies on when it bridges them by name, and which nothing else checked.

## Tests

- `JsonSchemaTest` — a parse/serialise round trip per message, 36 in total.
- `Ocpp12JsonParserErrorTest` — the parser error paths (validation on/off, ignored validation codes, forced field types) plus schema-tightness guards: `Reserved`, `GroundFailure`, the 1.5-only `StatusNotification` fields and the 1.5 `SampledValue` shape are all rejected, while a `BootNotification.conf` carrying only `status` is accepted. That last one also guards the resource prefix: it would fail if the 1.5 schema were picked up from the classpath.
- `Ocpp12FactoryTest` — the two cases asserting that 1.2 over WebSocket is rejected become tests of the supported behaviour, and a new end-to-end test runs a real WebSocket round trip (`authorize` charge point → central system, `remoteStartTransaction` central system → charge point).

## Verification

```
./gradlew :ocpp-1-2-json:test :toolkit:test
./gradlew build
```
